### PR TITLE
refactor(health-service): simplify health status tracking with global…

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -86,7 +86,7 @@ jwt_validation:
   # Datasource URL - must match the URL configured in your Webex Contact Center datasource
   # This should be the publicly accessible URL of your gateway (including port if non-standard)
   # Example: "https://your-gateway-domain.com:443"
-  datasource_url: "https://b9eb5df4443d.ngrok-free.app"
+  datasource_url: ""
   
   # Datasource schema UUID - typically this is the BYOVA schema UUID
   # This is the schema ID from https://github.com/webex/dataSourceSchemas

--- a/src/core/health_service.py
+++ b/src/core/health_service.py
@@ -14,18 +14,11 @@ from grpc_health.v1 import health_pb2, health_pb2_grpc
 
 from .virtual_agent_router import VirtualAgentRouter
 
-# Global router reference to avoid variable conflicts
-_global_router = None
-
-def set_global_router(router):
-    global _global_router
-    _global_router = router
-
 
 class HealthCheckService(health_pb2_grpc.HealthServicer):
     """
     Health check service that provides real-time health monitoring.
-    
+
     This service monitors the actual operational status of gateway components
     including connector availability and service health.
     """
@@ -33,19 +26,19 @@ class HealthCheckService(health_pb2_grpc.HealthServicer):
     def __init__(self, router: Optional[VirtualAgentRouter] = None):
         """
         Initialize the health check service.
-        
+
         Args:
             router: VirtualAgentRouter instance for checking connector health
         """
         super().__init__()
-        set_global_router(router)
+        self.router = router
         self.logger = logging.getLogger(__name__)
         self._lock = threading.Lock()
         self._service_status = {}
-        
+
         # Initialize with unknown status - will be updated on first check
         self._initialize_services()
-        
+
         self.logger.info("HealthCheckService initialized with real health monitoring")
 
     def _initialize_services(self):
@@ -53,44 +46,72 @@ class HealthCheckService(health_pb2_grpc.HealthServicer):
         with self._lock:
             # Initialize with unknown status - will be updated by health checks
             self._service_status[""] = health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
-            self._service_status["byova.gateway"] = health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
-            self._service_status["byova.VoiceVirtualAgentService"] = health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+            self._service_status["byova.gateway"] = (
+                health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+            )
+            self._service_status["byova.VoiceVirtualAgentService"] = (
+                health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+            )
 
     def _update_service_health(self):
         """Update service health status based on actual system state."""
         try:
             with self._lock:
-                # Use global router to avoid variable conflicts
-                if _global_router:
-                    available_agents = _global_router.get_all_available_agents()
+                # Check if router has available agents
+                if self.router:
+                    available_agents = self.router.get_all_available_agents()
                     has_agents = len(available_agents) > 0
-                    
+
                     if has_agents:
                         # Gateway is serving if it has available agents
-                        self._service_status["byova.gateway"] = health_pb2.HealthCheckResponse.SERVING
-                        self._service_status["byova.VoiceVirtualAgentService"] = health_pb2.HealthCheckResponse.SERVING
-                        self._service_status[""] = health_pb2.HealthCheckResponse.SERVING
+                        self._service_status["byova.gateway"] = (
+                            health_pb2.HealthCheckResponse.SERVING
+                        )
+                        self._service_status["byova.VoiceVirtualAgentService"] = (
+                            health_pb2.HealthCheckResponse.SERVING
+                        )
+                        self._service_status[""] = (
+                            health_pb2.HealthCheckResponse.SERVING
+                        )
                     else:
                         # No agents available
-                        self._service_status["byova.gateway"] = health_pb2.HealthCheckResponse.NOT_SERVING
-                        self._service_status["byova.VoiceVirtualAgentService"] = health_pb2.HealthCheckResponse.NOT_SERVING
-                        self._service_status[""] = health_pb2.HealthCheckResponse.NOT_SERVING
+                        self._service_status["byova.gateway"] = (
+                            health_pb2.HealthCheckResponse.NOT_SERVING
+                        )
+                        self._service_status["byova.VoiceVirtualAgentService"] = (
+                            health_pb2.HealthCheckResponse.NOT_SERVING
+                        )
+                        self._service_status[""] = (
+                            health_pb2.HealthCheckResponse.NOT_SERVING
+                        )
                 else:
                     # No router available
-                    self._service_status["byova.gateway"] = health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
-                    self._service_status["byova.VoiceVirtualAgentService"] = health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
-                    self._service_status[""] = health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+                    self._service_status["byova.gateway"] = (
+                        health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+                    )
+                    self._service_status["byova.VoiceVirtualAgentService"] = (
+                        health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+                    )
+                    self._service_status[""] = (
+                        health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+                    )
         except Exception as e:
             self.logger.error(f"Error updating service health: {e}")
             with self._lock:
-                self._service_status[""] = health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
-                self._service_status["byova.gateway"] = health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
-                self._service_status["byova.VoiceVirtualAgentService"] = health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+                self._service_status[""] = (
+                    health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+                )
+                self._service_status["byova.gateway"] = (
+                    health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+                )
+                self._service_status["byova.VoiceVirtualAgentService"] = (
+                    health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+                )
 
     def set_service_status(self, service_name: str, status: int):
         """
         Set the health status for a specific service.
-        
+
         Args:
             service_name: Name of the service
             status: Health status (from health_pb2.HealthCheckResponse)
@@ -102,26 +123,28 @@ class HealthCheckService(health_pb2_grpc.HealthServicer):
     def Check(self, request, context):
         """
         Check the health of a specific service.
-        
+
         Args:
             request: HealthCheckRequest containing service name
             context: gRPC context
-            
+
         Returns:
             HealthCheckResponse with current service status
         """
         service_name = request.service
-        
+
         # Update health status before responding
         self._update_service_health()
-        
+
         with self._lock:
             if service_name in self._service_status:
                 status = self._service_status[service_name]
                 self.logger.debug(f"Health check for '{service_name}': {status}")
                 return health_pb2.HealthCheckResponse(status=status)
             else:
-                self.logger.warning(f"Health check for unknown service '{service_name}': SERVICE_UNKNOWN")
+                self.logger.warning(
+                    f"Health check for unknown service '{service_name}': SERVICE_UNKNOWN"
+                )
                 return health_pb2.HealthCheckResponse(
                     status=health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
                 )
@@ -129,7 +152,7 @@ class HealthCheckService(health_pb2_grpc.HealthServicer):
     def Watch(self, request, context):
         """
         Watch for health status changes (streaming).
-        
+
         This is a placeholder implementation - streaming health updates
         are not currently implemented.
         """
@@ -141,7 +164,7 @@ class HealthCheckService(health_pb2_grpc.HealthServicer):
     def get_all_service_statuses(self):
         """
         Get all service statuses for monitoring dashboard.
-        
+
         Returns:
             Dictionary of service names to status codes
         """


### PR DESCRIPTION
… router reference

- Replace instance router reference with global router to avoid variable conflicts
- Remove redundant logging statements from health check updates
- Simplify health status retrieval in monitoring app using get_all_service_statuses()
- Implement status code to name conversion for consistent service status display
- Add degraded state detection when some but not all services are serving
- Remove unnecessary last_check_time tracking from health data response
- Clear datasource_url configuration value for security and flexibility
- Improve overall health determination logic to check both serving count and total services