### PR TITLE
chore(release): prepare v1.1.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -385,7 +385,7 @@ def main():
         print(f"🌐 Access URL: grpc://{host}:{port}")
         print(f"📁 Configuration: {config_path}")
         print(f"📝 Log Level: {gateway_config.get('level', 'INFO')}")
-        print(f"🔧 Gateway Version: {gateway_config.get('version', '1.0.0')}")
+        print(f"🔧 Gateway Version: {gateway_config.get('version', '1.1.0')}")
         print()
 
         # Print connector information

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "webex-byova-gateway"
-version = "1.0.0"
+version = "1.1.0"
 description = "Webex Contact Center BYOVA Gateway"
 authors = [
     {name = "Cisco", email = "support@cisco.com"}

--- a/src/monitoring/app.py
+++ b/src/monitoring/app.py
@@ -751,7 +751,7 @@ def get_configuration_data() -> Dict[str, Any]:
     config = {
         "gateway": {
             "name": "BYOVA Gateway",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "host": "0.0.0.0",
             "grpc_port": 50051,
             "web_port": 8080,


### PR DESCRIPTION
## Summary

- Bump all user-visible gateway version declarations to 1.1.0.
- Prepare the merged streaming Silero VAD functionality for a v1.1.0 release tag.

## Validation

- `PYTHONPATH=. venv/bin/pytest -q`
- `venv/bin/pip check`
- `git diff --check`