### PR TITLE
feat(gecx): make escalation and termination reliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ The gateway is configured via `config/config.yaml`. Key configuration sections:
 gateway:
   host: "0.0.0.0"
   port: 50051
+  streaming_max_workers: 100
+  # Safety ceiling; actual GECX terminal gating follows each WAV duration.
+  max_terminal_playback_seconds: 30
 
 # Connectors configuration
 connectors:
@@ -276,6 +279,10 @@ audio:
 - Multiple connectors can be configured simultaneously
 - Each connector must have a unique identifier (e.g., `local_audio_connector`, `aws_lex_connector`)
 - Connectors are loaded dynamically based on the `module` and `class` specified
+
+**Streaming Capacity**:
+- Bidirectional caller streams use the dedicated `streaming_max_workers` pool so long-lived calls do not consume the shared health and unary RPC executor
+- `max_terminal_playback_seconds` is a safety ceiling; GECX derives the actual terminal gate from each CES WAV response
 
 **AWS Credentials**:
 - Prefer environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) over hardcoded credentials

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,6 +4,11 @@
 gateway:
   host: "0.0.0.0"
   port: 50051
+  # Long-lived caller streams use a dedicated executor so they cannot starve
+  # health and unary RPCs on the shared gRPC worker pool.
+  streaming_max_workers: 100
+  # Safety ceiling only; the actual terminal gate is derived from each CES WAV.
+  max_terminal_playback_seconds: 30
 
 # Voice activity detection controls. The configured detector implementation is internal.
 voice_activity_detection:

--- a/docs/guides/byova-gecx-setup.md
+++ b/docs/guides/byova-gecx-setup.md
@@ -273,10 +273,11 @@ Agent escalates ─► CES EndSession { metadata: {...} }
 
 ### 2. Discover exactly what your agent sends
 
-The connector logs the raw metadata on every session end:
+The connector logs metadata key names on every session end without logging
+their values:
 
 ```
-[<conv>] [GECX] EndSession metadata: {'reason': 'agent_requested_handoff', ...}
+[<conv>] [GECX] EndSession metadata keys: ['reason', 'session_escalated']
 ```
 
 Trigger one escalation, read that log line, and confirm your keys match. If they
@@ -289,6 +290,10 @@ no code change needed:
     transfer_reason_keywords: ["transfer", "escalat", "human", "handoff"]
     transfer_reason_metadata_keys: ["reason", "type", "action"]
 ```
+
+For short-lived debugging only, `log_raw_terminal_metadata_debug: true` exposes
+the full metadata at DEBUG level. Leave it disabled when metadata may contain
+customer data or sensitive identifiers.
 
 When detected, you'll see:
 
@@ -336,6 +341,7 @@ remains immediate.
 | `transfer_metadata_keys` | No | EndSession metadata keys that, when truthy, trigger a human transfer (see [Escalation](#escalation-to-a-human-agent)) |
 | `transfer_reason_keywords` | No | Substrings that, if found in a reason/type metadata value, trigger a transfer |
 | `transfer_reason_metadata_keys` | No | Which metadata keys are scanned for `transfer_reason_keywords` |
+| `log_raw_terminal_metadata_debug` | No | Log raw EndSession metadata at DEBUG level; defaults to `false` because values may be sensitive |
 
 ## Authentication options
 
@@ -376,7 +382,7 @@ Search gateway logs for `[GECX]`:
 - `Barge-in` — interruption signal from CES
 - `gecx_terminal_decision` — the winning lifecycle decision, with
   `conversation_id`, CES `session`, `reason`, `outcome`, `source`,
-  `elapsed_seconds`, and terminal metadata
+  `elapsed_seconds`, and terminal metadata key names
 - `gecx_duplicate_terminal_suppressed` — a later terminal signal was ignored
 - `gecx_late_input_suppressed` / `gecx_late_server_message_suppressed` — caller
   or CES data arrived after the terminal decision

--- a/docs/guides/byova-gecx-setup.md
+++ b/docs/guides/byova-gecx-setup.md
@@ -176,6 +176,30 @@ detection, waits for CES `turn_completed` before returning the final turn to
 WxCC. This prevents a response that arrives after `END_OF_INPUT` from remaining
 queued when WxCC stops sending caller audio.
 
+All terminal causes pass through one session-scoped decision guard. The first
+decision rejects later caller input, finalizes agent audio received before the
+decision, half-closes the CES request stream once, and emits at most one
+terminal response. Duplicate `EndSession` messages and late CES output are
+ignored.
+
+| Terminal cause | WxCC outcome |
+|----------------|--------------|
+| CES `EndSession` with `session_escalated=true` (or a configured compatibility alias) | `TRANSFER_TO_AGENT` |
+| Normal CES `EndSession` | `SESSION_END` |
+| Turn-response timeout | `SESSION_END` |
+| CES `GoAway` | `SESSION_END` |
+| Unexpected CES stream failure/closure | `SESSION_END` |
+| WxCC cancellation or request-stream failure | Silent CES cleanup; no continuation is expected |
+| Normal WxCC request-stream half-close | Preserve the CES session for the next RPC carrying the same conversation ID |
+| Explicit gateway shutdown | Silent CES cleanup |
+
+CES documents [`EndSession`](https://docs.cloud.google.com/python/docs/reference/google-cloud-ces/latest/google.cloud.ces_v1.types.EndSession)
+as ending the session and prohibiting further input. CES documents
+[`GoAway`](https://docs.cloud.google.com/python/docs/reference/google-cloud-ces/latest/google.cloud.ces_v1.types.GoAway)
+as requiring half-close and reconnection. This connector deliberately ends the
+WxCC virtual-agent session on `GoAway`; reconnection, retry, and backoff are not
+implemented here.
+
 ### Speech boundaries
 
 The gateway's central Silero observer owns Webex `START_OF_INPUT` and
@@ -236,9 +260,11 @@ Agent escalates ─► CES EndSession { metadata: {...} }
 
 1. In your agent's instructions/playbook, define **when** to hand off (e.g.
    "if the caller asks for a human, or after two failed attempts, escalate").
-2. Make that escalation **end the session and attach metadata** that flags a
-   transfer. The connector recognizes, by default, any of these truthy metadata
-   keys: `transfer`, `transfer_to_agent`, `transfer_to_human`, `escalate`,
+2. Make that escalation **end the session and attach
+   `session_escalated=true` metadata**. This is the canonical CES escalation
+   signal and is checked first. For compatibility, the connector also recognizes
+   any of these truthy metadata keys: `transfer`, `transfer_to_agent`,
+   `transfer_to_human`, `escalate`,
    `escalation`, `escalated`, `session_escalated`, `handoff`, `human_handoff`,
    `live_agent_handoff` — and also a
    `reason`/`type`/`status`/`intent`/`action` value containing `transfer`,
@@ -267,7 +293,7 @@ no code change needed:
 When detected, you'll see:
 
 ```
-[<conv>] [GECX] Escalation detected -> TRANSFER_TO_AGENT (reason: ...)
+gecx_terminal_decision conversation_id=<conv> session=<session> reason=escalation outcome=transfer source=ces_end_session ...
 ```
 
 ### 3. Handle it in the WxCC flow
@@ -275,6 +301,21 @@ When detected, you'll see:
 The Virtual Agent element emits a **Transfer** branch on `TRANSFER_TO_AGENT`.
 Wire that branch to a queue that routes to human agents. (A normal
 `SESSION_END` ends the virtual-agent interaction without a transfer.)
+
+When CES includes its final spoken announcement with `EndSession`, the GECX
+connector sends the CES announcement first and follows it with a prompt-free
+terminal response. WxCC skips prompt audio when `TRANSFER_TO_AGENT` shares the
+same response, so this ordering lets the full CES announcement play and then
+transfers as soon as playback completes. The gateway calculates that gate from
+the CES WAV byte rate and data length rather than applying a fixed termination
+delay.
+
+The connector also keeps CES text with its matching CES audio until the turn is
+complete. This prevents WxCC from synthesizing a separate text-only prompt ahead
+of the provider audio, which would duplicate speech and delay later responses.
+For GECX, the gateway also places `END_OF_INPUT` on that completed response
+instead of sending it as a preceding standalone response; `START_OF_INPUT`
+remains immediate.
 
 ## Configuration reference
 
@@ -320,6 +361,7 @@ and grant the represented identity `roles/ces.client`.
 | No audio to caller (silence) | WxCC needs a WAV-wrapped clip, not raw audio. Confirm `Audio out: NNNN bytes WAV` in logs and `output_audio_encoding: MULAW` / `output_sample_rate_hertz: 8000`. See [How it works](#audio-format-wxcc-expects-a-self-describing-wav-clip). |
 | Garbled speech | Confirm the gateway logs the declared WxCC encoding/sample rate; use `force_input_format: "wxcc"` only when the client omits metadata |
 | No response after `END_OF_INPUT` | Check for `turn_completed` or a turn-completion timeout in `[GECX]` logs; increase `turn_response_timeout_seconds` if the agent regularly needs more than 30 seconds |
+| `GoAway` from CES | The connector intentionally emits one `SESSION_END` and half-closes CES; it does not reconnect in the current implementation |
 | Import error | `pip install google-cloud-ces` |
 
 ## Logs
@@ -332,6 +374,14 @@ Search gateway logs for `[GECX]`:
 - `Audio out: NNNN bytes WAV (MMMM raw)` — one WAV clip emitted per agent turn
   (`NNNN` includes the WAV header; `MMMM` is the raw CES bytes buffered)
 - `Barge-in` — interruption signal from CES
+- `gecx_terminal_decision` — the winning lifecycle decision, with
+  `conversation_id`, CES `session`, `reason`, `outcome`, `source`,
+  `elapsed_seconds`, and terminal metadata
+- `gecx_duplicate_terminal_suppressed` — a later terminal signal was ignored
+- `gecx_late_input_suppressed` / `gecx_late_server_message_suppressed` — caller
+  or CES data arrived after the terminal decision
+- `gecx_session_join_timeout` — the CES stream thread did not stop within the
+  cleanup join window
 
 ## Related documentation
 

--- a/main.py
+++ b/main.py
@@ -266,6 +266,16 @@ def create_jwt_interceptor(
             return None
 
 
+def create_streaming_executor(servicer, max_workers: int):
+    """Create and attach a dedicated executor for caller streaming RPCs."""
+    executor = futures.ThreadPoolExecutor(
+        max_workers=max_workers,
+        thread_name_prefix="byova-stream",
+    )
+    servicer.ProcessCallerInput.__func__.experimental_thread_pool = executor
+    return executor
+
+
 def main():
     """
     Main entry point for the BYOVA Gateway.
@@ -279,6 +289,7 @@ def main():
     """
     logger = None
     server = None
+    streaming_executor = None
     try:
         # Select an environment-specific configuration when requested.
         config_path = os.environ.get("GATEWAY_CONFIG", "config/config.yaml")
@@ -299,17 +310,24 @@ def main():
         router.load_connectors(router_config)
         logger.info("Connectors loaded successfully")
 
+        # Get server configuration
+        gateway_config = config.get("gateway", {})
+
         # Create WxCCGatewayServer
         vad_config = config.get("voice_activity_detection", {})
-        server = WxCCGatewayServer(router, vad_config)
+        server = WxCCGatewayServer(
+            router,
+            vad_config,
+            max_terminal_playback_seconds=float(
+                gateway_config.get("max_terminal_playback_seconds", 30.0)
+            ),
+        )
         logger.info("WxCCGatewayServer created")
 
         # Create health service with router for real health monitoring
         health_service = HealthCheckService(router)
         logger.info("HealthCheckService created with real health monitoring")
 
-        # Get server configuration
-        gateway_config = config.get("gateway", {})
         host = gateway_config.get("host", "0.0.0.0")
         port = int(os.environ.get("PORT", gateway_config.get("port", 50051)))
 
@@ -341,6 +359,15 @@ def main():
                 ],
             )
             logger.info("gRPC server created without interceptors")
+
+        # Keep long-lived bidirectional caller streams, including response-
+        # derived playback waits, off the shared executor used by health and
+        # unary RPCs. gRPC Python selects this method-specific pool through the
+        # handler's supported experimental_thread_pool attribute.
+        streaming_executor = create_streaming_executor(
+            server,
+            int(gateway_config.get("streaming_max_workers", 100)),
+        )
 
         # Add servicer to the server
         add_VoiceVirtualAgentServicer_to_server(server, grpc_server)
@@ -439,6 +466,8 @@ def main():
             if server:
                 server.shutdown()
             grpc_server.stop(grace=5)
+            if streaming_executor:
+                streaming_executor.shutdown(wait=False, cancel_futures=True)
             logger.info("Gateway shutdown complete")
 
     except Exception as e:

--- a/src/connectors/gecx_connector.py
+++ b/src/connectors/gecx_connector.py
@@ -14,7 +14,10 @@ import queue
 import re
 import struct
 import threading
+import time
 import uuid
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, Generator, Iterator, Optional, Tuple
 
 try:
@@ -46,7 +49,7 @@ except ImportError:
     Request = None
     client_options_lib = None
 
-from .i_vendor_connector import EventTypes, IVendorConnector
+from .i_vendor_connector import IVendorConnector
 
 # CES session IDs: [a-zA-Z0-9][a-zA-Z0-9-_]{4,62}
 _SESSION_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9\-_]{4,62}$")
@@ -54,6 +57,38 @@ _SESSION_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9\-_]{4,62}$")
 # Sentinel objects for the inbound control queue
 _AUDIO_END = object()
 _STREAM_STOP = object()
+
+
+class GECXTerminalReason(str, Enum):
+    """Reasons a GECX streaming session can reach a terminal state."""
+
+    NORMAL_END = "normal_end"
+    ESCALATION = "escalation"
+    TIMEOUT = "timeout"
+    GO_AWAY = "go_away"
+    CLIENT_CANCELLED = "client_cancelled"
+    CLIENT_HALF_CLOSE = "client_half_close"
+    STREAM_ERROR = "stream_error"
+    EXPLICIT_SHUTDOWN = "explicit_shutdown"
+
+
+class GECXTerminalOutcome(str, Enum):
+    """Response behavior selected by a GECX terminal decision."""
+
+    TRANSFER = "transfer"
+    SESSION_END = "session_end"
+    SILENT = "silent"
+
+
+@dataclass(frozen=True)
+class GECXTerminalDecision:
+    """The immutable first terminal decision for a GECX session."""
+
+    reason: GECXTerminalReason
+    outcome: GECXTerminalOutcome
+    source: str
+    metadata: Dict[str, Any]
+    decided_at: float
 
 
 def _make_ces_session_id() -> str:
@@ -102,10 +137,15 @@ class GECXStreamingSession:
         self._stream_error: Optional[str] = None
         self._thread: Optional[threading.Thread] = None
         self._lock = threading.Lock()
-        # CES streams TTS output as many small frames per agent turn. WxCC
-        # expects one complete, self-describing audio clip per prompt, so we
-        # accumulate the raw frames here and emit a single WAV-wrapped clip when
-        # the turn completes.
+        self._lifecycle_lock = threading.Lock()
+        self._terminal_decision: Optional[GECXTerminalDecision] = None
+        self._join_attempted = False
+        self._started_at = time.monotonic()
+        # CES streams text and TTS output separately during an agent turn. WxCC
+        # expects one complete prompt, so keep both forms together and emit one
+        # response when the turn completes. Sending the text early as its own
+        # prompt makes WxCC synthesize it and blocks the later CES audio/event.
+        self._text_buffer: list[str] = []
         self._audio_buffer = bytearray()
 
     def start(self) -> None:
@@ -121,28 +161,90 @@ class GECXStreamingSession:
         if self._stream_error:
             raise RuntimeError(self._stream_error)
 
-    def stop(self) -> None:
-        """Signal the stream to stop and wait for the thread."""
-        self._stop_event.set()
-        self._turn_completed.set()
-        self.inbound_queue.put(_STREAM_STOP)
-        if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=10)
+    @property
+    def terminal_decision(self) -> Optional[GECXTerminalDecision]:
+        """Return the session's first terminal decision, if one exists."""
+        with self._lifecycle_lock:
+            return self._terminal_decision
 
-    def enqueue_audio(self, audio_chunk: bytes) -> None:
+    @property
+    def is_terminal(self) -> bool:
+        """Return whether the session has made a terminal decision."""
+        return self.terminal_decision is not None
+
+    def stop(
+        self,
+        reason: GECXTerminalReason = GECXTerminalReason.EXPLICIT_SHUTDOWN,
+        source: str = "connector_stop",
+    ) -> None:
+        """Terminate silently and wait once for the stream thread."""
+        self.terminate(
+            reason=reason,
+            outcome=GECXTerminalOutcome.SILENT,
+            source=source,
+        )
+
+        with self._lifecycle_lock:
+            if self._join_attempted:
+                return
+            self._join_attempted = True
+            thread = self._thread
+
+        if thread and thread.is_alive() and thread is not threading.current_thread():
+            thread.join(timeout=10)
+            if thread.is_alive():
+                self.logger.error(
+                    "gecx_session_join_timeout conversation_id=%s session=%s "
+                    "terminal_reason=%s",
+                    self.conversation_id,
+                    self.session_path,
+                    self.terminal_decision.reason.value,
+                )
+
+    def enqueue_audio(self, audio_chunk: bytes) -> bool:
         """Queue an audio chunk for the CES stream."""
-        if audio_chunk:
+        if not audio_chunk:
+            return False
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                self._log_late_input("audio")
+                return False
             self.inbound_queue.put(audio_chunk)
+        return True
 
-    def enqueue_text(self, text: str) -> None:
+    def enqueue_text(self, text: str) -> bool:
         """Queue a text turn for the CES stream."""
-        if text:
+        if not text:
+            return False
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                self._log_late_input("text")
+                return False
             self.inbound_queue.put(("text", text))
+        return True
 
-    def enqueue_event(self, event_name: str) -> None:
+    def enqueue_event(self, event_name: str) -> bool:
         """Queue an event for the CES stream."""
-        if event_name:
+        if not event_name:
+            return False
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                self._log_late_input("event")
+                return False
             self.inbound_queue.put(("event", event_name))
+        return True
+
+    def _log_late_input(self, input_type: str) -> None:
+        decision = self._terminal_decision
+        self.logger.warning(
+            "gecx_late_input_suppressed conversation_id=%s session=%s "
+            "input_type=%s terminal_reason=%s terminal_outcome=%s",
+            self.conversation_id,
+            self.session_path,
+            input_type,
+            decision.reason.value if decision else "unknown",
+            decision.outcome.value if decision else "unknown",
+        )
 
     def drain_responses(self) -> list[Dict[str, Any]]:
         """Non-blocking drain of outbound connector responses."""
@@ -154,12 +256,17 @@ class GECXStreamingSession:
                 break
         return responses
 
-    def begin_input_turn(self) -> None:
+    def begin_input_turn(self) -> bool:
         """Reset completion tracking when gateway VAD detects caller speech."""
-        self._turn_completed.clear()
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                self._log_late_input("speech_boundary")
+                return False
+            self._turn_completed.clear()
+        return True
 
     def wait_for_turn_responses(
-        self, timeout: float
+        self, timeout: float, *, terminate_on_timeout: bool = True
     ) -> Tuple[bool, list[Dict[str, Any]]]:
         """Wait for CES to complete the current turn, then drain its responses."""
         completed = self._turn_completed.wait(timeout=timeout)
@@ -169,7 +276,148 @@ class GECXStreamingSession:
                 self.conversation_id,
                 timeout,
             )
+            if terminate_on_timeout:
+                self.terminate(
+                    reason=GECXTerminalReason.TIMEOUT,
+                    outcome=GECXTerminalOutcome.SESSION_END,
+                    source="turn_response_timeout",
+                    metadata={"timeout_seconds": timeout},
+                )
         return completed, self.drain_responses()
+
+    def terminate(
+        self,
+        reason: GECXTerminalReason,
+        outcome: GECXTerminalOutcome,
+        source: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        response_text: str = "",
+    ) -> bool:
+        """Make the session's terminal decision exactly once.
+
+        The winning call rejects future input, preserves already-buffered agent
+        audio when the response channel is usable, half-closes the CES request
+        stream, wakes response waiters, and optionally queues one canonical
+        terminal response for the gateway. Preserved audio is attached to that
+        same response so WxCC receives the final prompt and terminal event
+        atomically. Later calls are no-ops.
+        """
+        terminal_metadata = dict(metadata or {})
+        decided_at = time.monotonic()
+
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                current = self._terminal_decision
+                self.logger.warning(
+                    "gecx_duplicate_terminal_suppressed conversation_id=%s "
+                    "session=%s attempted_reason=%s attempted_outcome=%s "
+                    "attempted_source=%s terminal_reason=%s terminal_outcome=%s "
+                    "terminal_source=%s",
+                    self.conversation_id,
+                    self.session_path,
+                    reason.value,
+                    outcome.value,
+                    source,
+                    current.reason.value,
+                    current.outcome.value,
+                    current.source,
+                )
+                return False
+
+            decision = GECXTerminalDecision(
+                reason=reason,
+                outcome=outcome,
+                source=source,
+                metadata=terminal_metadata,
+                decided_at=decided_at,
+            )
+            self._terminal_decision = decision
+            self._stop_event.set()
+
+            with self._lock:
+                buffered_text = "".join(self._text_buffer)
+                raw_audio = bytes(self._audio_buffer)
+                self._text_buffer = []
+                self._audio_buffer = bytearray()
+
+            # Queue the stop sentinel exactly once. The request generator also
+            # checks terminal state after dequeuing to close the final race where
+            # it already pulled caller audio as termination was decided.
+            self.inbound_queue.put(_STREAM_STOP)
+
+            # Preserve final CES output ahead of the terminal event. WxCC skips
+            # a prompt when TRANSFER_TO_AGENT shares its response, so the audio
+            # must be its own response. Gateway backpressure then advances to
+            # the terminal response as soon as prompt playback completes.
+            preserved_output = False
+            if outcome != GECXTerminalOutcome.SILENT:
+                wav_audio = (
+                    self.connector.wrap_output_audio(raw_audio) if raw_audio else b""
+                )
+                if buffered_text or wav_audio:
+                    self.outbound_queue.put(
+                        self.connector.create_response(
+                            conversation_id=self.conversation_id,
+                            message_type="audio" if wav_audio else "agent_response",
+                            text=buffered_text or response_text,
+                            audio_content=wav_audio,
+                            barge_in_enabled=False,
+                            response_type="final",
+                        )
+                    )
+                    preserved_output = True
+
+            terminal_response = self._create_terminal_response(
+                decision,
+                response_text="" if preserved_output else (response_text or None),
+            )
+            if terminal_response is not None:
+                self.outbound_queue.put(terminal_response)
+
+            # Set completion only after the terminal response is visible so a
+            # waiter cannot wake and drain the queue too early.
+            self._turn_completed.set()
+
+        self.logger.info(
+            "gecx_terminal_decision conversation_id=%s session=%s reason=%s "
+            "outcome=%s source=%s elapsed_seconds=%.3f metadata=%s",
+            self.conversation_id,
+            self.session_path,
+            reason.value,
+            outcome.value,
+            source,
+            decided_at - self._started_at,
+            terminal_metadata or {},
+        )
+        return True
+
+    def _create_terminal_response(
+        self,
+        decision: GECXTerminalDecision,
+        response_text: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Build one canonical connector response for a terminal decision."""
+        if decision.outcome == GECXTerminalOutcome.SILENT:
+            return None
+        if decision.outcome == GECXTerminalOutcome.TRANSFER:
+            return self.connector.create_response(
+                conversation_id=self.conversation_id,
+                message_type="transfer",
+                text=(
+                    "Transferring you to an agent."
+                    if response_text is None
+                    else response_text
+                ),
+                barge_in_enabled=False,
+                response_type="final",
+            )
+        return self.connector.create_response(
+            conversation_id=self.conversation_id,
+            message_type="session_end",
+            text=response_text or "",
+            barge_in_enabled=False,
+            response_type="final",
+        )
 
     def _request_generator(self) -> Iterator[Any]:
         """Yield BidiSessionClientMessage objects for bidi_run_session."""
@@ -199,7 +447,7 @@ class GECXStreamingSession:
         yield ces_v1.BidiSessionClientMessage(config=session_config)
         self._stream_started.set()
 
-        if self.initial_message:
+        if self.initial_message and not self.is_terminal:
             yield ces_v1.BidiSessionClientMessage(
                 realtime_input=ces_v1.SessionInput(text=self.initial_message)
             )
@@ -211,6 +459,8 @@ class GECXStreamingSession:
                 continue
 
             if item is _STREAM_STOP:
+                break
+            if self.is_terminal:
                 break
             if item is _AUDIO_END:
                 continue
@@ -240,18 +490,38 @@ class GECXStreamingSession:
                     break
                 self._handle_server_message(server_message)
         except Exception as exc:
-            self.logger.error(
-                f"[{self.conversation_id}] [GECX] BidiRunSession error: {exc}",
-                exc_info=True,
-            )
-            self._stream_error = str(exc)
-            self.outbound_queue.put(
-                self.connector.create_error_response(
-                    conversation_id=self.conversation_id,
-                    error_message=f"GECX stream error: {exc}",
+            if self.is_terminal:
+                self.logger.debug(
+                    "gecx_stream_closed_after_terminal conversation_id=%s "
+                    "session=%s error=%r",
+                    self.conversation_id,
+                    self.session_path,
+                    exc,
                 )
-            )
+            else:
+                self.logger.error(
+                    "gecx_stream_error conversation_id=%s session=%s error=%r",
+                    self.conversation_id,
+                    self.session_path,
+                    exc,
+                    exc_info=True,
+                )
+                self._stream_error = str(exc)
+                self.terminate(
+                    reason=GECXTerminalReason.STREAM_ERROR,
+                    outcome=GECXTerminalOutcome.SESSION_END,
+                    source="bidi_run_session_exception",
+                    metadata={"error": str(exc)},
+                )
         finally:
+            if not self.is_terminal:
+                self._stream_error = "CES response stream closed without EndSession"
+                self.terminate(
+                    reason=GECXTerminalReason.STREAM_ERROR,
+                    outcome=GECXTerminalOutcome.SESSION_END,
+                    source="bidi_run_session_closed",
+                    metadata={"error": self._stream_error},
+                )
             self._stream_started.set()
             self._turn_completed.set()
 
@@ -259,6 +529,18 @@ class GECXStreamingSession:
         """Map CES server messages to BYOVA connector responses."""
         conversation_id = self.conversation_id
         turn_completed = False
+
+        if self.is_terminal:
+            decision = self.terminal_decision
+            self.logger.warning(
+                "gecx_late_server_message_suppressed conversation_id=%s "
+                "session=%s terminal_reason=%s terminal_outcome=%s",
+                conversation_id,
+                self.session_path,
+                decision.reason.value,
+                decision.outcome.value,
+            )
+            return
 
         if message.recognition_result and message.recognition_result.transcript:
             transcript = message.recognition_result.transcript.strip()
@@ -269,16 +551,22 @@ class GECXStreamingSession:
 
         if message.interruption_signal:
             self.logger.info(f"[{conversation_id}] [GECX] Barge-in interruption signal")
-            with self._lock:
-                self._audio_buffer = bytearray()
-                while not self.outbound_queue.empty():
-                    try:
-                        self.outbound_queue.get_nowait()
-                    except queue.Empty:
-                        break
+            # Keep lifecycle -> audio locking consistent with terminate() so a
+            # concurrent interruption cannot erase the winning terminal response.
+            with self._lifecycle_lock:
+                if self._terminal_decision is None:
+                    with self._lock:
+                        self._text_buffer = []
+                        self._audio_buffer = bytearray()
+                    while True:
+                        try:
+                            self.outbound_queue.get_nowait()
+                        except queue.Empty:
+                            break
 
         if message.session_output:
             output = message.session_output
+            has_terminal_output = bool(output.end_session)
             response_type = (
                 "final" if output.turn_completed else "partial"
             )
@@ -287,14 +575,7 @@ class GECXStreamingSession:
                 self.logger.info(
                     f"[{conversation_id}] [GECX] Agent: '{output.text}'"
                 )
-                self.outbound_queue.put(
-                    self.connector.create_response(
-                        conversation_id=conversation_id,
-                        message_type="agent_response",
-                        text=output.text,
-                        response_type=response_type,
-                    )
-                )
+                self._buffer_active_text(output.text)
 
             audio_bytes = self._decode_output_audio(output.audio)
             if audio_bytes:
@@ -302,83 +583,102 @@ class GECXStreamingSession:
                     f"[{conversation_id}] [GECX] Buffered audio frame: "
                     f"{len(audio_bytes)} bytes"
                 )
-                with self._lock:
-                    self._audio_buffer.extend(audio_bytes)
+                self._buffer_active_audio(audio_bytes)
 
             # A completed turn means the full agent utterance has been streamed;
             # emit it to WxCC as a single WAV clip.
-            if output.turn_completed:
+            if output.turn_completed and not has_terminal_output:
                 self._flush_audio_buffer()
                 turn_completed = True
 
-            if output.end_session:
-                self._flush_audio_buffer()
-                self._emit_session_end(conversation_id, output)
-                self._begin_half_close()
+            if has_terminal_output:
+                self._handle_end_session(
+                    conversation_id,
+                    output.end_session,
+                )
                 turn_completed = True
 
         if message.end_session:
-            self._flush_audio_buffer()
-            self._emit_session_end(conversation_id, message.end_session)
-            self._begin_half_close()
+            self._handle_end_session(conversation_id, message.end_session)
             turn_completed = True
 
         if message.go_away:
-            self.logger.warning(f"[{conversation_id}] [GECX] GoAway received, stopping stream")
-            self._stop_event.set()
+            self.terminate(
+                reason=GECXTerminalReason.GO_AWAY,
+                outcome=GECXTerminalOutcome.SESSION_END,
+                source="ces_go_away",
+            )
             turn_completed = True
 
         if turn_completed:
             self._turn_completed.set()
 
-    def _begin_half_close(self) -> None:
-        """Half-close the client side of the bidi stream after CES ends a session.
+    def _enqueue_active_response(self, response: Dict[str, Any]) -> bool:
+        """Queue a non-terminal response only while the session is active."""
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                return False
+            self.outbound_queue.put(response)
+        return True
 
-        CES requires the client to stop sending (half-close) within 30s of an
-        ``EndSession`` message; otherwise it aborts the RPC with
-        ``CLIENT_HALF_CLOSE_TIMEOUT``, which surfaces as a stream error and
-        tears the turn down before the transfer/session-end response is
-        delivered to WxCC. Signalling the request generator to return
-        half-closes the stream cleanly so the RPC completes normally.
-        """
-        if self._stop_event.is_set():
-            return
-        self.logger.info(
-            f"[{self.conversation_id}] [GECX] EndSession received; half-closing stream"
-        )
-        self._stop_event.set()
-        # Unblock the request generator immediately so it returns (rather than
-        # waiting for its queue poll to time out).
-        self.inbound_queue.put(_STREAM_STOP)
+    def _buffer_active_audio(self, audio_bytes: bytes) -> bool:
+        """Buffer agent audio only while the session is active."""
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                return False
+            with self._lock:
+                self._audio_buffer.extend(audio_bytes)
+        return True
+
+    def _buffer_active_text(self, text: str) -> bool:
+        """Buffer CES text until its matching audio turn is complete."""
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                return False
+            with self._lock:
+                self._text_buffer.append(text)
+        return True
 
     def _flush_audio_buffer(self, response_type: str = "final") -> bool:
-        """Wrap buffered CES audio in a WxCC WAV clip and enqueue it.
+        """Emit buffered CES text and audio as one WxCC prompt response.
 
-        Returns True if a clip was emitted. Safe to call repeatedly; it is a
-        no-op when the buffer is empty.
+        Returns True if a response was emitted. Safe to call repeatedly; it is
+        a no-op when both buffers are empty.
         """
-        with self._lock:
-            if not self._audio_buffer:
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                with self._lock:
+                    self._text_buffer = []
+                    self._audio_buffer = bytearray()
                 return False
-            raw_audio = bytes(self._audio_buffer)
-            self._audio_buffer = bytearray()
+            with self._lock:
+                if not self._text_buffer and not self._audio_buffer:
+                    return False
+                buffered_text = "".join(self._text_buffer)
+                raw_audio = bytes(self._audio_buffer)
+                self._text_buffer = []
+                self._audio_buffer = bytearray()
 
-        wav_audio = self.connector.wrap_output_audio(raw_audio)
-        if not wav_audio:
-            return False
-
-        self.logger.info(
-            f"[{self.conversation_id}] [GECX] Audio out: {len(wav_audio)} bytes "
-            f"WAV ({len(raw_audio)} raw)"
-        )
-        self.outbound_queue.put(
-            self.connector.create_response(
-                conversation_id=self.conversation_id,
-                message_type="audio",
-                audio_content=wav_audio,
-                response_type=response_type,
+            wav_audio = (
+                self.connector.wrap_output_audio(raw_audio) if raw_audio else b""
             )
-        )
+            if not buffered_text and not wav_audio:
+                return False
+
+            if wav_audio:
+                self.logger.info(
+                    f"[{self.conversation_id}] [GECX] Audio out: "
+                    f"{len(wav_audio)} bytes WAV ({len(raw_audio)} raw)"
+                )
+            self.outbound_queue.put(
+                self.connector.create_response(
+                    conversation_id=self.conversation_id,
+                    message_type="audio" if wav_audio else "agent_response",
+                    text=buffered_text,
+                    audio_content=wav_audio,
+                    response_type=response_type,
+                )
+            )
         return True
 
     @staticmethod
@@ -408,6 +708,23 @@ class GECXStreamingSession:
         """
         truthy = {"true", "1", "yes", "y", "on"}
         lowered = {str(k).lower(): v for k, v in metadata.items()}
+
+        # CES documents this exact flag for escalated EndSession messages. Keep
+        # it ahead of configurable aliases so the supported contract is obvious.
+        escalated = lowered.get("session_escalated")
+        if (
+            escalated is True
+            or (
+                isinstance(escalated, (int, float))
+                and not isinstance(escalated, bool)
+                and escalated != 0
+            )
+            or (
+                isinstance(escalated, str)
+                and escalated.strip().lower() in truthy
+            )
+        ):
+            return True, str(lowered.get("reason", "session_escalated"))
 
         # 1) Explicit boolean-ish flag keys.
         for key in self.connector.transfer_metadata_keys:
@@ -447,7 +764,12 @@ class GECXStreamingSession:
 
         return False, ""
 
-    def _emit_session_end(self, conversation_id: str, end_obj: Any) -> None:
+    def _handle_end_session(
+        self,
+        conversation_id: str,
+        end_obj: Any,
+        response_text: str = "",
+    ) -> None:
         metadata = self._metadata_to_dict(end_obj)
 
         # Log the raw metadata so operators can see exactly what the agent sends
@@ -458,32 +780,24 @@ class GECXStreamingSession:
 
         is_transfer, reason = self._detect_transfer(metadata)
         if is_transfer:
-            self.logger.info(
-                f"[{conversation_id}] [GECX] Escalation detected -> "
-                f"TRANSFER_TO_AGENT (reason: {reason or 'agent_requested_transfer'})"
-            )
-            self.outbound_queue.put(
-                self.connector.create_transfer_response(
-                    conversation_id=conversation_id,
-                    text="Transferring you to an agent.",
-                    reason=reason or "agent_requested_transfer",
-                )
+            self.terminate(
+                reason=GECXTerminalReason.ESCALATION,
+                outcome=GECXTerminalOutcome.TRANSFER,
+                source="ces_end_session",
+                metadata={
+                    "transfer_reason": reason or "agent_requested_transfer",
+                    "end_session": metadata,
+                },
+                response_text=response_text,
             )
             return
 
-        end_event = self.connector.create_output_event(
-            EventTypes.SESSION_END,
-            "session_ended_by_gecx",
-            metadata or None,
-        )
-        self.outbound_queue.put(
-            self.connector.create_response(
-                conversation_id=conversation_id,
-                message_type="session_end",
-                text="",
-                response_type="final",
-                output_events=[end_event],
-            )
+        self.terminate(
+            reason=GECXTerminalReason.NORMAL_END,
+            outcome=GECXTerminalOutcome.SESSION_END,
+            source="ces_end_session",
+            metadata={"end_session": metadata},
+            response_text=response_text,
         )
 
     @staticmethod
@@ -801,6 +1115,14 @@ class GECXConnector(IVendorConnector):
         """GECX receives caller audio frames as they arrive from WxCC."""
         return "streaming"
 
+    def should_cleanup_on_client_stream_end(self) -> bool:
+        """Close CES after WxCC cancellation or request-stream failure."""
+        return True
+
+    def should_coalesce_speech_end_with_response(self) -> bool:
+        """Send END_OF_INPUT with the completed CES prompt and terminal event."""
+        return True
+
     def handle_speech_boundary(
         self, conversation_id: str, message_data: Dict[str, Any]
     ) -> Generator[Dict[str, Any], None, None]:
@@ -812,6 +1134,10 @@ class GECXConnector(IVendorConnector):
             self.logger.warning(
                 "[GECX] No active stream for speech boundary: %s", conversation_id
             )
+            return
+
+        if stream_session.is_terminal:
+            yield from stream_session.drain_responses()
             return
 
         boundary_kind = message_data.get("speech_boundary", {}).get("kind")
@@ -853,8 +1179,13 @@ class GECXConnector(IVendorConnector):
             welcome_text = "Connected to GECX agent"
             got_text = False
             welcome_audio = b""
-            _, greeting_responses = stream_session.wait_for_turn_responses(timeout=8.0)
+            terminal_response: Optional[Dict[str, Any]] = None
+            _, greeting_responses = stream_session.wait_for_turn_responses(
+                timeout=8.0, terminate_on_timeout=False
+            )
             for response in greeting_responses:
+                if response.get("message_type") in {"transfer", "session_end"}:
+                    terminal_response = response
                 if response.get("text") and not got_text:
                     welcome_text = response["text"]
                     got_text = True
@@ -870,6 +1201,18 @@ class GECXConnector(IVendorConnector):
                 for response in stream_session.drain_responses():
                     if response.get("audio_content"):
                         welcome_audio = response["audio_content"]
+
+            # CES may legitimately end or escalate during the initial turn.
+            # Preserve that first terminal decision instead of following it with
+            # a contradictory session-start response. Fold any greeting output
+            # received first into the one response shape start_conversation can
+            # return so the terminal event does not discard agent output.
+            if terminal_response is not None:
+                if got_text:
+                    terminal_response["text"] = welcome_text
+                if welcome_audio:
+                    terminal_response["audio_content"] = welcome_audio
+                return terminal_response
 
             return self.create_session_start_response(
                 conversation_id=conversation_id,
@@ -896,6 +1239,10 @@ class GECXConnector(IVendorConnector):
             self.logger.error(
                 f"[GECX] No active stream for conversation: {conversation_id}"
             )
+            return
+
+        if stream_session.is_terminal:
+            yield from stream_session.drain_responses()
             return
 
         message_type = message_data.get("input_type") or message_data.get("type", "audio")
@@ -955,7 +1302,9 @@ class GECXConnector(IVendorConnector):
                 conversation_id=conversation_id,
             )
 
-        stream_session.enqueue_audio(audio_chunk)
+        if not stream_session.enqueue_audio(audio_chunk):
+            yield from stream_session.drain_responses()
+            return
 
         for response in stream_session.drain_responses():
             yield response
@@ -969,8 +1318,12 @@ class GECXConnector(IVendorConnector):
         text = message_data.get("text", "")
         if not text:
             return
-        stream_session.begin_input_turn()
-        stream_session.enqueue_text(text)
+        if not stream_session.begin_input_turn():
+            yield from stream_session.drain_responses()
+            return
+        if not stream_session.enqueue_text(text):
+            yield from stream_session.drain_responses()
+            return
         _, responses = stream_session.wait_for_turn_responses(
             timeout=self.turn_response_timeout_seconds
         )
@@ -987,8 +1340,12 @@ class GECXConnector(IVendorConnector):
             event_name = message_data["event_data"].get("name", "")
         if not event_name:
             return
-        stream_session.begin_input_turn()
-        stream_session.enqueue_event(event_name)
+        if not stream_session.begin_input_turn():
+            yield from stream_session.drain_responses()
+            return
+        if not stream_session.enqueue_event(event_name):
+            yield from stream_session.drain_responses()
+            return
         _, responses = stream_session.wait_for_turn_responses(
             timeout=self.turn_response_timeout_seconds
         )
@@ -997,13 +1354,31 @@ class GECXConnector(IVendorConnector):
     def end_conversation(
         self, conversation_id: str, message_data: Optional[Dict[str, Any]] = None
     ) -> None:
-        self.logger.info(f"[GECX] Ending conversation: {conversation_id}")
+        termination_reason = (message_data or {}).get(
+            "termination_reason", "explicit_shutdown"
+        )
+        reason_map = {
+            "client_cancelled": GECXTerminalReason.CLIENT_CANCELLED,
+            "client_half_close": GECXTerminalReason.CLIENT_HALF_CLOSE,
+            "stream_error": GECXTerminalReason.STREAM_ERROR,
+        }
+        terminal_reason = reason_map.get(
+            termination_reason, GECXTerminalReason.EXPLICIT_SHUTDOWN
+        )
+        self.logger.info(
+            "gecx_end_conversation conversation_id=%s reason=%s",
+            conversation_id,
+            termination_reason,
+        )
         with self.sessions_lock:
             stream_session = self.streaming_sessions.pop(conversation_id, None)
             self.detected_formats.pop(conversation_id, None)
 
         if stream_session:
-            stream_session.stop()
+            stream_session.stop(
+                reason=terminal_reason,
+                source=f"gateway_{termination_reason}",
+            )
 
     def convert_wxcc_to_vendor(self, grpc_data: Any) -> Dict[str, Any]:
         return {"data": grpc_data, "converted_for": "gecx"}

--- a/src/connectors/gecx_connector.py
+++ b/src/connectors/gecx_connector.py
@@ -18,7 +18,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Generator, Iterator, Optional, Tuple
+from typing import Any, Dict, Generator, Iterator, Optional, Tuple, Union
 
 try:
     import audioop
@@ -380,14 +380,20 @@ class GECXStreamingSession:
 
         self.logger.info(
             "gecx_terminal_decision conversation_id=%s session=%s reason=%s "
-            "outcome=%s source=%s elapsed_seconds=%.3f metadata=%s",
+            "outcome=%s source=%s elapsed_seconds=%.3f metadata_keys=%s "
+            "end_session_metadata_keys=%s",
             self.conversation_id,
             self.session_path,
             reason.value,
             outcome.value,
             source,
             decided_at - self._started_at,
-            terminal_metadata or {},
+            sorted(terminal_metadata),
+            sorted(
+                terminal_metadata.get("end_session", {})
+                if isinstance(terminal_metadata.get("end_session"), dict)
+                else {}
+            ),
         )
         return True
 
@@ -567,9 +573,6 @@ class GECXStreamingSession:
         if message.session_output:
             output = message.session_output
             has_terminal_output = bool(output.end_session)
-            response_type = (
-                "final" if output.turn_completed else "partial"
-            )
 
             if output.text:
                 self.logger.info(
@@ -772,11 +775,17 @@ class GECXStreamingSession:
     ) -> None:
         metadata = self._metadata_to_dict(end_obj)
 
-        # Log the raw metadata so operators can see exactly what the agent sends
-        # on escalation and map transfer_metadata_keys accordingly.
         self.logger.info(
-            f"[{conversation_id}] [GECX] EndSession metadata: {metadata or '{}'}"
+            "[%s] [GECX] EndSession metadata keys: %s",
+            conversation_id,
+            sorted(metadata),
         )
+        if self.connector.log_raw_terminal_metadata_debug:
+            self.logger.debug(
+                "[%s] [GECX] Raw EndSession metadata: %s",
+                conversation_id,
+                metadata,
+            )
 
         is_transfer, reason = self._detect_transfer(metadata)
         if is_transfer:
@@ -889,6 +898,9 @@ class GECXConnector(IVendorConnector):
         self.force_input_format = config.get("force_input_format", "").lower()
         self.turn_response_timeout_seconds = float(
             config.get("turn_response_timeout_seconds", 30.0)
+        )
+        self.log_raw_terminal_metadata_debug = bool(
+            config.get("log_raw_terminal_metadata_debug", False)
         )
         self.agents = config.get("agents", ["GECX Agent"])
 
@@ -1158,7 +1170,7 @@ class GECXConnector(IVendorConnector):
 
     def start_conversation(
         self, conversation_id: str, request_data: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    ) -> Union[Dict[str, Any], list[Dict[str, Any]]]:
         self.logger.info(f"[GECX] Starting conversation: {conversation_id}")
         try:
             session_id = _make_ces_session_id()
@@ -1179,6 +1191,7 @@ class GECXConnector(IVendorConnector):
             welcome_text = "Connected to GECX agent"
             got_text = False
             welcome_audio = b""
+            ordered_greeting_responses: list[Dict[str, Any]] = []
             terminal_response: Optional[Dict[str, Any]] = None
             _, greeting_responses = stream_session.wait_for_turn_responses(
                 timeout=8.0, terminate_on_timeout=False
@@ -1186,6 +1199,8 @@ class GECXConnector(IVendorConnector):
             for response in greeting_responses:
                 if response.get("message_type") in {"transfer", "session_end"}:
                     terminal_response = response
+                else:
+                    ordered_greeting_responses.append(response)
                 if response.get("text") and not got_text:
                     welcome_text = response["text"]
                     got_text = True
@@ -1199,20 +1214,37 @@ class GECXConnector(IVendorConnector):
             # caller still hears the greeting.
             if not welcome_audio and stream_session._flush_audio_buffer():
                 for response in stream_session.drain_responses():
+                    if response.get("message_type") in {"transfer", "session_end"}:
+                        terminal_response = response
+                    else:
+                        ordered_greeting_responses.append(response)
                     if response.get("audio_content"):
                         welcome_audio = response["audio_content"]
 
             # CES may legitimately end or escalate during the initial turn.
-            # Preserve that first terminal decision instead of following it with
-            # a contradictory session-start response. Fold any greeting output
-            # received first into the one response shape start_conversation can
-            # return so the terminal event does not discard agent output.
+            # Preserve output and the terminal decision as ordered responses.
+            # WxCC skips prompt audio when TRANSFER_TO_AGENT shares its response.
             if terminal_response is not None:
-                if got_text:
-                    terminal_response["text"] = welcome_text
-                if welcome_audio:
-                    terminal_response["audio_content"] = welcome_audio
-                return terminal_response
+                terminal_response = dict(terminal_response)
+                if terminal_response.get("text") or terminal_response.get(
+                    "audio_content"
+                ):
+                    terminal_audio = terminal_response.get("audio_content", b"")
+                    ordered_greeting_responses.append(
+                        self.create_response(
+                            conversation_id=conversation_id,
+                            message_type=(
+                                "audio" if terminal_audio else "agent_response"
+                            ),
+                            text=terminal_response.get("text", ""),
+                            audio_content=terminal_audio,
+                            barge_in_enabled=False,
+                            response_type="final",
+                        )
+                    )
+                    terminal_response["text"] = ""
+                    terminal_response["audio_content"] = b""
+                return [*ordered_greeting_responses, terminal_response]
 
             return self.create_session_start_response(
                 conversation_id=conversation_id,

--- a/src/connectors/i_vendor_connector.py
+++ b/src/connectors/i_vendor_connector.py
@@ -42,6 +42,25 @@ class IVendorConnector(ABC):
         del conversation_id
         return True
 
+    def should_cleanup_on_client_stream_end(self) -> bool:
+        """Return whether an abnormal WxCC stream end should clean up state.
+
+        Connectors opt in when their vendor session cannot safely remain open
+        after cancellation or a request-stream failure. A normal half-close is
+        a WxCC continuation boundary and never invokes this capability. The
+        default preserves existing behavior for current connectors.
+        """
+        return False
+
+    def should_coalesce_speech_end_with_response(self) -> bool:
+        """Return whether END_OF_INPUT should share the connector response.
+
+        The default keeps the existing two-response gateway behavior. Streaming
+        connectors may opt in when a standalone END_OF_INPUT response would
+        apply backpressure before their completed audio response can be sent.
+        """
+        return False
+
     def handle_speech_boundary(
         self, conversation_id: str, message_data: Dict[str, Any]
     ) -> Optional[Iterator[Optional[Dict[str, Any]]]]:

--- a/src/core/virtual_agent_router.py
+++ b/src/core/virtual_agent_router.py
@@ -204,6 +204,18 @@ class VirtualAgentRouter:
             agent_id
         ).should_observe_speech_boundaries(conversation_id)
 
+    def should_cleanup_on_client_stream_end(self, agent_id: str) -> bool:
+        """Return whether the connector opts into stream-end cleanup."""
+        return self.get_connector_for_agent(
+            agent_id
+        ).should_cleanup_on_client_stream_end()
+
+    def should_coalesce_speech_end_with_response(self, agent_id: str) -> bool:
+        """Return whether END_OF_INPUT should share the connector response."""
+        return self.get_connector_for_agent(
+            agent_id
+        ).should_coalesce_speech_end_with_response()
+
     def route_request(self, agent_id: str, method: str, *args, **kwargs) -> Any:
         """
         Route a request to the appropriate connector.

--- a/src/core/wxcc_gateway_server.py
+++ b/src/core/wxcc_gateway_server.py
@@ -228,12 +228,28 @@ class ConversationProcessor:
                     event_type,
                     self.conversation_id,
                 )
-                response = self._convert_connector_response_to_grpc({
+                boundary_event = {
+                    "event_type": event_type,
+                    "name": "" if event_type == "START_OF_INPUT" else "end_of_input",
+                }
+                boundary_connector_response = {
                     "message_type": "silence",
-                    "output_events": [{"event_type": event_type, "name": "" if event_type == "START_OF_INPUT" else "end_of_input"}],
-                })
-                if response is not None:
-                    yield response
+                    "output_events": [boundary_event],
+                }
+                coalesce_speech_end = (
+                    signal.kind == "speech_ended"
+                    and self.router.should_coalesce_speech_end_with_response(
+                        self.virtual_agent_id
+                    )
+                )
+
+                if not coalesce_speech_end:
+                    response = self._convert_connector_response_to_grpc(
+                        boundary_connector_response
+                    )
+                    if response is not None:
+                        yield response
+
                 boundary_response = self.router.route_request(
                     self.virtual_agent_id,
                     "handle_speech_boundary",
@@ -245,9 +261,26 @@ class ConversationProcessor:
                         "speech_boundary": {"kind": signal.kind},
                     },
                 )
-                yield from self._iter_grpc_connector_responses(
-                    boundary_response, include_single_response=False
-                )
+                if coalesce_speech_end:
+                    coalesced_responses = list(
+                        self._iter_grpc_connector_responses(
+                            boundary_response,
+                            additional_output_event=boundary_event,
+                            delay_terminal_after_audio=True,
+                        )
+                    )
+                    if coalesced_responses:
+                        yield from coalesced_responses
+                    else:
+                        response = self._convert_connector_response_to_grpc(
+                            boundary_connector_response
+                        )
+                        if response is not None:
+                            yield response
+                else:
+                    yield from self._iter_grpc_connector_responses(
+                        boundary_response, include_single_response=False
+                    )
 
         except Exception as e:
             self.logger.error(
@@ -256,7 +289,12 @@ class ConversationProcessor:
             yield self._create_error_response(f"Audio processing error: {str(e)}")
 
     def _iter_grpc_connector_responses(
-        self, connector_response, *, include_single_response: bool = True
+        self,
+        connector_response,
+        *,
+        include_single_response: bool = True,
+        additional_output_event: Optional[Dict[str, Any]] = None,
+        delay_terminal_after_audio: bool = False,
     ) -> Iterator[VoiceVAResponse]:
         """Convert a connector response or response iterator to gRPC responses."""
         is_iterator = hasattr(connector_response, "__iter__") and not isinstance(
@@ -266,6 +304,12 @@ class ConversationProcessor:
             return
 
         responses = connector_response if is_iterator else (connector_response,)
+        pending_output_event = (
+            dict(additional_output_event)
+            if additional_output_event is not None
+            else None
+        )
+        pending_playback_seconds = 0.0
 
         for response in responses:
             if response is None:
@@ -274,9 +318,54 @@ class ConversationProcessor:
                 )
                 continue
 
+            if (
+                delay_terminal_after_audio
+                and pending_playback_seconds > 0
+                and isinstance(response, dict)
+                and response.get("message_type") in {"transfer", "session_end"}
+            ):
+                self.logger.info(
+                    "Delaying terminal response %.3f seconds for CES audio "
+                    "playback in conversation %s",
+                    pending_playback_seconds,
+                    self.conversation_id,
+                )
+                time.sleep(pending_playback_seconds)
+                pending_playback_seconds = 0.0
+
+            if pending_output_event is not None and isinstance(response, dict):
+                response = dict(response)
+                output_events = list(response.get("output_events", []))
+                output_events.append(pending_output_event)
+                response["output_events"] = output_events
+                pending_output_event = None
+
+            if delay_terminal_after_audio and isinstance(response, dict):
+                pending_playback_seconds = self._wav_playback_seconds(
+                    response.get("audio_content", b"")
+                )
+
             grpc_response = self._convert_connector_response_to_grpc(response)
             if grpc_response is not None:
                 yield grpc_response
+
+    @staticmethod
+    def _wav_playback_seconds(audio_content: bytes) -> float:
+        """Return playback duration for the connector's canonical WAV shape."""
+        if (
+            not isinstance(audio_content, bytes)
+            or len(audio_content) < 44
+            or audio_content[:4] != b"RIFF"
+            or audio_content[8:12] != b"WAVE"
+            or audio_content[36:40] != b"data"
+        ):
+            return 0.0
+
+        byte_rate = int.from_bytes(audio_content[28:32], "little")
+        data_size = int.from_bytes(audio_content[40:44], "little")
+        if byte_rate <= 0 or data_size <= 0:
+            return 0.0
+        return data_size / byte_rate
 
     def _process_dtmf_input(self, dtmf_input) -> Iterator[VoiceVAResponse]:
         """Process DTMF input."""
@@ -377,6 +466,7 @@ class ConversationProcessor:
                         "conversation_id": self.conversation_id,
                         "virtual_agent_id": self.virtual_agent_id,
                         "input_type": "conversation_end",
+                        "termination_reason": "client_session_end",
                     }
 
                     # Route to connector to end conversation
@@ -833,14 +923,15 @@ class ConversationProcessor:
         )
         return va_response
 
-    def cleanup(self):
-        """Clean up conversation resources."""
+    def cleanup(self, termination_reason: str = "gateway_cleanup"):
+        """Clean up conversation resources with a lifecycle reason."""
         try:
             # End the conversation with the connector
             message_data = {
                 "conversation_id": self.conversation_id,
                 "virtual_agent_id": self.virtual_agent_id,
                 "input_type": "conversation_end",
+                "termination_reason": termination_reason,
             }
             self.router.route_request(
                 self.virtual_agent_id,
@@ -897,15 +988,19 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
 
         # Clean up all active conversations
         for conversation_id in list(self.conversations.keys()):
-            self._cleanup_conversation(conversation_id)
+            self._cleanup_conversation(
+                conversation_id, termination_reason="gateway_shutdown"
+            )
 
         self.logger.info("WxCCGatewayServer shutdown complete")
 
-    def _cleanup_conversation(self, conversation_id: str):
+    def _cleanup_conversation(
+        self, conversation_id: str, termination_reason: str = "gateway_cleanup"
+    ):
         """Clean up a specific conversation."""
         if conversation_id in self.conversations:
             try:
-                self.conversations[conversation_id].cleanup()
+                self.conversations[conversation_id].cleanup(termination_reason)
             except Exception as e:
                 self.logger.warning(
                     f"Error cleaning up conversation {conversation_id}: {e}"
@@ -1047,6 +1142,7 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
         conversation_id = None
         agent_id = None
         processor = None
+        stream_end_reason = "client_half_close"
 
         try:
             for request in request_iterator:
@@ -1128,21 +1224,49 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
                 # Track message event
                 self.add_connection_event("message", conversation_id, agent_id)
 
+        except grpc.RpcError as e:
+            if e.code() == grpc.StatusCode.CANCELLED:
+                stream_end_reason = "client_cancelled"
+            else:
+                stream_end_reason = "stream_error"
+                self.logger.error(f"Error in ProcessCallerInput stream: {e}")
+                context.set_code(grpc.StatusCode.INTERNAL)
+                context.set_details(f"Stream error: {str(e)}")
         except Exception as e:
+            stream_end_reason = "stream_error"
             self.logger.error(f"Error in ProcessCallerInput stream: {e}")
             context.set_code(grpc.StatusCode.INTERNAL)
             context.set_details(f"Stream error: {str(e)}")
         finally:
-            # Clean up conversation if it can be deleted
+            if context and not context.is_active():
+                stream_end_reason = "client_cancelled"
+
+            # WxCC normally half-closes one request RPC and reconnects with the
+            # same conversation ID for subsequent caller input. Preserve the
+            # processor and vendor session across that continuation boundary.
+            # Connector opt-in applies only to cancellation and actual request
+            # stream failures, where no continuation is expected.
             if conversation_id and conversation_id in self.conversations:
                 processor = self.conversations[conversation_id]
-                if processor.can_be_deleted:
-                    self.logger.debug(
-                        f"Cleaning up completed conversation {conversation_id}"
+                cleanup_on_stream_end = (
+                    stream_end_reason != "client_half_close"
+                    and self.router.should_cleanup_on_client_stream_end(agent_id)
+                    is True
+                )
+                if processor.can_be_deleted or cleanup_on_stream_end:
+                    termination_reason = (
+                        "completed" if processor.can_be_deleted else stream_end_reason
                     )
-                    self._cleanup_conversation(conversation_id)
+                    self.logger.debug(
+                        "Cleaning up conversation %s (reason=%s)",
+                        conversation_id,
+                        termination_reason,
+                    )
+                    self._cleanup_conversation(
+                        conversation_id, termination_reason=termination_reason
+                    )
                     self.add_connection_event(
-                        "end", conversation_id, agent_id, reason="completed"
+                        "end", conversation_id, agent_id, reason=termination_reason
                     )
                 else:
                     self.logger.debug(

--- a/src/core/wxcc_gateway_server.py
+++ b/src/core/wxcc_gateway_server.py
@@ -6,6 +6,7 @@ Webex Contact Center and the virtual agent connectors.
 """
 
 import logging
+import threading
 import time
 from typing import Any, Dict, Iterator, Optional
 
@@ -57,6 +58,7 @@ class ConversationProcessor:
     def __init__(
         self, conversation_id: str, virtual_agent_id: str, router: VirtualAgentRouter,
         vad_config: Optional[Dict[str, Any]] = None,
+        max_terminal_playback_seconds: float = 30.0,
     ):
         self.conversation_id = conversation_id
         self.virtual_agent_id = virtual_agent_id
@@ -67,6 +69,10 @@ class ConversationProcessor:
         self.start_time = time.time()
         self.session_started = False
         self.can_be_deleted = False
+        self.max_terminal_playback_seconds = max(
+            0.0, float(max_terminal_playback_seconds)
+        )
+        self._stream_cancel_event = threading.Event()
         vad_settings = vad_config or {}
         self.vad_fallback_sample_rate_hertz = vad_settings.get(
             "fallback_sample_rate_hertz", 8000
@@ -83,6 +89,10 @@ class ConversationProcessor:
         self.logger.info(
             f"Created conversation processor for {conversation_id} with agent {virtual_agent_id}"
         )
+
+    def set_stream_cancel_event(self, cancel_event: threading.Event) -> None:
+        """Attach the cancellation signal for the active WxCC request stream."""
+        self._stream_cancel_event = cancel_event
 
     def process_request(self, request: VoiceVARequest) -> Iterator[VoiceVAResponse]:
         """
@@ -139,6 +149,16 @@ class ConversationProcessor:
                 f"Start Conversation Connector response received for {self.conversation_id}"
             )
             self.logger.debug(f"Connector response type: {type(connector_response)}")
+            is_iterator = hasattr(connector_response, "__iter__") and not isinstance(
+                connector_response, (dict, str, bytes)
+            )
+            if is_iterator:
+                yield from self._iter_grpc_connector_responses(
+                    connector_response,
+                    delay_terminal_after_audio=True,
+                )
+                return
+
             if isinstance(connector_response, dict):
                 self.logger.debug(
                     f"Connector response keys: {list(connector_response.keys())}"
@@ -327,10 +347,31 @@ class ConversationProcessor:
                 self.logger.info(
                     "Delaying terminal response %.3f seconds for CES audio "
                     "playback in conversation %s",
-                    pending_playback_seconds,
+                    min(
+                        pending_playback_seconds,
+                        self.max_terminal_playback_seconds,
+                    ),
                     self.conversation_id,
                 )
-                time.sleep(pending_playback_seconds)
+                wait_seconds = min(
+                    pending_playback_seconds,
+                    self.max_terminal_playback_seconds,
+                )
+                if pending_playback_seconds > wait_seconds:
+                    self.logger.warning(
+                        "Capped terminal playback wait from %.3f to %.3f seconds "
+                        "for conversation %s",
+                        pending_playback_seconds,
+                        wait_seconds,
+                        self.conversation_id,
+                    )
+                if self._stream_cancel_event.wait(wait_seconds):
+                    self.logger.info(
+                        "Suppressed delayed terminal response after stream "
+                        "cancellation for conversation %s",
+                        self.conversation_id,
+                    )
+                    return
                 pending_playback_seconds = 0.0
 
             if pending_output_event is not None and isinstance(response, dict):
@@ -959,7 +1000,12 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
     virtual agent connectors.
     """
 
-    def __init__(self, router: VirtualAgentRouter, vad_config: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self,
+        router: VirtualAgentRouter,
+        vad_config: Optional[Dict[str, Any]] = None,
+        max_terminal_playback_seconds: float = 30.0,
+    ) -> None:
         """
         Initialize the WxCC Gateway Server.
 
@@ -969,6 +1015,7 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
         """
         self.router = router
         self.vad_config = vad_config or {}
+        self.max_terminal_playback_seconds = max_terminal_playback_seconds
         self.logger = logging.getLogger(__name__)
 
         # Conversation state management - track active conversations by conversation_id
@@ -1143,6 +1190,9 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
         agent_id = None
         processor = None
         stream_end_reason = "client_half_close"
+        stream_cancel_event = threading.Event()
+        if context:
+            context.add_callback(stream_cancel_event.set)
 
         try:
             for request in request_iterator:
@@ -1178,7 +1228,11 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
                     # Create or get conversation processor
                     if conversation_id not in self.conversations:
                         processor = ConversationProcessor(
-                            conversation_id, agent_id, self.router, self.vad_config
+                            conversation_id,
+                            agent_id,
+                            self.router,
+                            self.vad_config,
+                            self.max_terminal_playback_seconds,
                         )
                         self.conversations[conversation_id] = processor
                         self.add_connection_event("start", conversation_id, agent_id)
@@ -1187,9 +1241,26 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
                         )
                     else:
                         processor = self.conversations[conversation_id]
+                        if processor.virtual_agent_id != agent_id:
+                            self.logger.error(
+                                "Rejected conversation %s reconnection with agent %s; "
+                                "existing agent is %s",
+                                conversation_id,
+                                agent_id,
+                                processor.virtual_agent_id,
+                            )
+                            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+                            context.set_details(
+                                "virtual_agent_id does not match the existing "
+                                "conversation"
+                            )
+                            return
+                        agent_id = processor.virtual_agent_id
                         self.logger.debug(
                             f"Using existing conversation processor for {conversation_id}"
                         )
+
+                    processor.set_stream_cancel_event(stream_cancel_event)
 
                 # Log the input type being processed
                 if request.HasField("audio_input"):
@@ -1238,6 +1309,7 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
             context.set_code(grpc.StatusCode.INTERNAL)
             context.set_details(f"Stream error: {str(e)}")
         finally:
+            stream_cancel_event.set()
             if context and not context.is_active():
                 stream_end_reason = "client_cancelled"
 
@@ -1248,6 +1320,7 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
             # stream failures, where no continuation is expected.
             if conversation_id and conversation_id in self.conversations:
                 processor = self.conversations[conversation_id]
+                agent_id = processor.virtual_agent_id
                 cleanup_on_stream_end = (
                     stream_end_reason != "client_half_close"
                     and self.router.should_cleanup_on_client_stream_end(agent_id)

--- a/tests/test_gecx_connector.py
+++ b/tests/test_gecx_connector.py
@@ -4,6 +4,7 @@ Tests for the GECX (CX Agent Studio / CES) connector.
 
 from __future__ import annotations
 
+import logging
 import re
 import threading
 from types import SimpleNamespace
@@ -285,6 +286,22 @@ class TestServerMessageMapping:
         responses = self._end_session(connector, {"custom_handoff": "yes"})
         assert responses[0]["message_type"] == "transfer"
 
+    def test_terminal_logs_metadata_keys_without_values(self, connector, caplog):
+        caplog.set_level(logging.INFO)
+
+        self._end_session(
+            connector,
+            {
+                "session_escalated": True,
+                "customer_email": "guest@example.com",
+                "reason": "private routing identifier",
+            },
+        )
+
+        assert "customer_email" in caplog.text
+        assert "guest@example.com" not in caplog.text
+        assert "private routing identifier" not in caplog.text
+
     def test_end_session_with_escalation_key_name_emits_transfer(self, connector):
         # Key-name keyword match catches naming variants generically.
         responses = self._end_session(connector, {"agent_escalated_call": True})
@@ -337,6 +354,37 @@ class TestServerMessageMapping:
 
         assert session.terminal_decision.reason == GECXTerminalReason.GO_AWAY
         assert session.drain_responses()[0]["message_type"] == "session_end"
+
+    def test_initial_escalation_keeps_greeting_and_transfer_separate(
+        self, connector
+    ):
+        combined_terminal_response = connector.create_response(
+            conversation_id="conv-1",
+            message_type="transfer",
+            text="Let me connect you now.",
+            audio_content=b"RIFFgreeting",
+            barge_in_enabled=False,
+            response_type="final",
+        )
+        stream_session = MagicMock()
+        stream_session.wait_for_turn_responses.return_value = (
+            True,
+            [combined_terminal_response],
+        )
+
+        with patch(
+            "src.connectors.gecx_connector.GECXStreamingSession",
+            return_value=stream_session,
+        ):
+            responses = connector.start_conversation("conv-1", {})
+
+        assert [response["message_type"] for response in responses] == [
+            "audio",
+            "transfer",
+        ]
+        assert responses[0]["audio_content"] == b"RIFFgreeting"
+        assert responses[1]["audio_content"] == b""
+        assert responses[1]["text"] == ""
 
 
 class TestTerminalLifecycle:

--- a/tests/test_gecx_connector.py
+++ b/tests/test_gecx_connector.py
@@ -5,6 +5,7 @@ Tests for the GECX (CX Agent Studio / CES) connector.
 from __future__ import annotations
 
 import re
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,9 @@ import pytest
 from src.connectors.gecx_connector import (
     GECXConnector,
     GECXStreamingSession,
+    GECXTerminalOutcome,
+    GECXTerminalReason,
+    _STREAM_STOP,
     _make_ces_session_id,
     _ces_audio_encoding,
 )
@@ -103,6 +107,26 @@ class TestRequestGenerator:
 
         assert second.realtime_input.text == "Hello"
 
+    def test_no_caller_audio_is_yielded_after_terminal_decision(self, connector):
+        session = GECXStreamingSession(
+            connector=connector,
+            conversation_id="conv-1",
+            session_path="projects/p/locations/us/apps/a/sessions/s1",
+            deployment_path=connector.deployment_path,
+            initial_message=None,
+        )
+        session.enqueue_audio(b"caller audio")
+        session.terminate(
+            GECXTerminalReason.NORMAL_END,
+            GECXTerminalOutcome.SESSION_END,
+            "test",
+        )
+
+        generator = session._request_generator()
+        next(generator)  # Session config is always the first CES message.
+        with pytest.raises(StopIteration):
+            next(generator)
+
 
 class TestServerMessageMapping:
     def test_session_output_maps_to_connector_responses(self, connector):
@@ -131,14 +155,14 @@ class TestServerMessageMapping:
         completed, responses = session.wait_for_turn_responses(timeout=0.1)
 
         assert completed
-        assert len(responses) == 2
-        assert responses[0]["message_type"] == "agent_response"
+        assert len(responses) == 1
+        assert responses[0]["message_type"] == "audio"
         assert responses[0]["text"] == "Hi there"
         assert responses[0]["response_type"] == "final"
-        assert responses[1]["message_type"] == "audio"
-        # Audio is buffered per turn and wrapped in a WxCC WAV container.
-        assert responses[1]["audio_content"].startswith(b"RIFF")
-        assert responses[1]["audio_content"].endswith(b"\x01\x02")
+        # Text and audio are emitted atomically so WxCC does not synthesize a
+        # duplicate text-only prompt before playing the CES audio.
+        assert responses[0]["audio_content"].startswith(b"RIFF")
+        assert responses[0]["audio_content"].endswith(b"\x01\x02")
 
     def test_end_session_emits_session_end_event(self, connector):
         session = GECXStreamingSession(
@@ -159,8 +183,10 @@ class TestServerMessageMapping:
         session._handle_server_message(message)
         responses = session.drain_responses()
 
+        assert len(responses) == 1
         assert responses[0]["message_type"] == "session_end"
-        assert responses[0]["output_events"][0]["event_type"] == "SESSION_END"
+        assert responses[0]["output_events"] == []
+        assert session.terminal_decision.reason == GECXTerminalReason.NORMAL_END
 
     def _end_session(self, connector, metadata):
         session = GECXStreamingSession(
@@ -183,11 +209,9 @@ class TestServerMessageMapping:
         responses = self._end_session(
             connector, {"transfer": True, "reason": "caller asked for a human"}
         )
+        assert len(responses) == 1
         assert responses[0]["message_type"] == "transfer"
-        assert responses[0]["output_events"][0]["event_type"] == "TRANSFER_TO_HUMAN"
-        assert responses[0]["output_events"][0]["metadata"]["reason"] == (
-            "caller asked for a human"
-        )
+        assert responses[0]["output_events"] == []
 
     def test_end_session_with_reason_keyword_emits_transfer(self, connector):
         responses = self._end_session(
@@ -202,6 +226,63 @@ class TestServerMessageMapping:
     def test_end_session_with_session_escalated_flag_emits_transfer(self, connector):
         # This is the exact payload GECX emits on escalation.
         responses = self._end_session(connector, {"session_escalated": True})
+        assert responses[0]["message_type"] == "transfer"
+
+    def test_session_output_end_session_uses_nested_metadata(self, connector):
+        session = GECXStreamingSession(
+            connector=connector,
+            conversation_id="conv-1",
+            session_path="projects/p/locations/us/apps/a/sessions/s1",
+            deployment_path=connector.deployment_path,
+        )
+        text_message = SimpleNamespace(
+            recognition_result=None,
+            interruption_signal=None,
+            end_session=None,
+            go_away=None,
+            session_output=SimpleNamespace(
+                text="Certainly. Let me connect you with a hotel specialist.",
+                audio=b"",
+                turn_completed=False,
+                end_session=False,
+            ),
+        )
+        terminal_message = SimpleNamespace(
+            recognition_result=None,
+            interruption_signal=None,
+            end_session=None,
+            go_away=None,
+            session_output=SimpleNamespace(
+                text="",
+                audio=b"transfer audio",
+                turn_completed=True,
+                end_session=SimpleNamespace(
+                    metadata={"session_escalated": True}
+                ),
+            ),
+        )
+
+        session._handle_server_message(text_message)
+        assert session.drain_responses() == []
+        session._handle_server_message(terminal_message)
+
+        assert session.terminal_decision.reason == GECXTerminalReason.ESCALATION
+        responses = session.drain_responses()
+        assert [response["message_type"] for response in responses] == [
+            "audio",
+            "transfer",
+        ]
+        assert responses[0]["text"] == (
+            "Certainly. Let me connect you with a hotel specialist."
+        )
+        assert responses[0]["audio_content"].endswith(b"transfer audio")
+        assert responses[0]["output_events"] == []
+        assert responses[1]["text"] == ""
+        assert responses[1]["audio_content"] == b""
+
+    def test_configurable_escalation_alias_remains_supported(self, connector):
+        connector.transfer_metadata_keys = ["custom_handoff"]
+        responses = self._end_session(connector, {"custom_handoff": "yes"})
         assert responses[0]["message_type"] == "transfer"
 
     def test_end_session_with_escalation_key_name_emits_transfer(self, connector):
@@ -237,6 +318,181 @@ class TestServerMessageMapping:
         assert session._stop_event.is_set()
         assert session.inbound_queue.get_nowait() is gecx_mod._STREAM_STOP
 
+    def test_go_away_ends_session_without_reconnection(self, connector):
+        session = GECXStreamingSession(
+            connector=connector,
+            conversation_id="conv-1",
+            session_path="projects/p/locations/us/apps/a/sessions/s1",
+            deployment_path=connector.deployment_path,
+        )
+        message = SimpleNamespace(
+            recognition_result=None,
+            interruption_signal=None,
+            session_output=None,
+            end_session=None,
+            go_away=SimpleNamespace(),
+        )
+
+        session._handle_server_message(message)
+
+        assert session.terminal_decision.reason == GECXTerminalReason.GO_AWAY
+        assert session.drain_responses()[0]["message_type"] == "session_end"
+
+
+class TestTerminalLifecycle:
+    def _session(self, connector):
+        return GECXStreamingSession(
+            connector=connector,
+            conversation_id="conv-1",
+            session_path="projects/p/locations/us/apps/a/sessions/s1",
+            deployment_path=connector.deployment_path,
+        )
+
+    def test_turn_timeout_decides_session_end(self, connector):
+        session = self._session(connector)
+
+        completed, responses = session.wait_for_turn_responses(timeout=0)
+
+        assert not completed
+        assert session.terminal_decision.reason == GECXTerminalReason.TIMEOUT
+        assert [response["message_type"] for response in responses] == ["session_end"]
+
+    def test_unexpected_stream_exception_decides_session_end(self, connector):
+        session = self._session(connector)
+        connector.session_client.bidi_run_session.side_effect = RuntimeError("boom")
+
+        session._run_stream()
+
+        assert session.terminal_decision.reason == GECXTerminalReason.STREAM_ERROR
+        assert session.terminal_decision.outcome == GECXTerminalOutcome.SESSION_END
+        assert session.drain_responses()[0]["message_type"] == "session_end"
+
+    def test_first_terminal_decision_wins_under_race(self, connector):
+        session = self._session(connector)
+        barrier = threading.Barrier(3)
+        results = []
+
+        def decide(reason, outcome):
+            barrier.wait()
+            results.append(session.terminate(reason, outcome, "race_test"))
+
+        threads = [
+            threading.Thread(
+                target=decide,
+                args=(GECXTerminalReason.NORMAL_END, GECXTerminalOutcome.SESSION_END),
+            ),
+            threading.Thread(
+                target=decide,
+                args=(GECXTerminalReason.ESCALATION, GECXTerminalOutcome.TRANSFER),
+            ),
+        ]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join()
+
+        assert sorted(results) == [False, True]
+        assert len(session.drain_responses()) == 1
+        queued_items = []
+        while not session.inbound_queue.empty():
+            queued_items.append(session.inbound_queue.get_nowait())
+        assert queued_items.count(_STREAM_STOP) == 1
+
+    def test_duplicate_end_and_late_output_are_suppressed(self, connector):
+        session = self._session(connector)
+        normal_end = SimpleNamespace(
+            recognition_result=None,
+            interruption_signal=None,
+            session_output=None,
+            go_away=None,
+            end_session=SimpleNamespace(metadata={}),
+        )
+        late_output = SimpleNamespace(
+            recognition_result=None,
+            interruption_signal=None,
+            end_session=None,
+            go_away=None,
+            session_output=SimpleNamespace(
+                text="late prompt",
+                audio=b"late audio",
+                turn_completed=True,
+                end_session=False,
+            ),
+        )
+
+        session._handle_server_message(normal_end)
+        session._handle_server_message(normal_end)
+        session._handle_server_message(late_output)
+
+        responses = session.drain_responses()
+        assert [response["message_type"] for response in responses] == ["session_end"]
+        assert session.enqueue_audio(b"late caller audio") is False
+
+    def test_agent_output_before_terminal_is_preserved(self, connector):
+        session = self._session(connector)
+        output = SimpleNamespace(
+            recognition_result=None,
+            interruption_signal=None,
+            end_session=None,
+            go_away=None,
+            session_output=SimpleNamespace(
+                text="I can help with that",
+                audio=b"",
+                turn_completed=False,
+                end_session=False,
+            ),
+        )
+
+        session._handle_server_message(output)
+        session._handle_end_session("conv-1", SimpleNamespace(metadata={}))
+
+        responses = session.drain_responses()
+        assert [response["message_type"] for response in responses] == [
+            "agent_response",
+            "session_end",
+        ]
+        assert responses[0]["text"] == "I can help with that"
+        assert responses[1]["text"] == ""
+
+    def test_buffered_agent_audio_before_terminal_is_preserved(self, connector):
+        session = self._session(connector)
+        session._buffer_active_audio(b"agent audio")
+
+        session.terminate(
+            GECXTerminalReason.GO_AWAY,
+            GECXTerminalOutcome.SESSION_END,
+            "test_go_away",
+        )
+
+        responses = session.drain_responses()
+        assert [response["message_type"] for response in responses] == [
+            "audio",
+            "session_end",
+        ]
+        assert responses[0]["audio_content"].endswith(b"agent audio")
+
+    @pytest.mark.parametrize(
+        ("gateway_reason", "terminal_reason"),
+        [
+            ("client_cancelled", GECXTerminalReason.CLIENT_CANCELLED),
+            ("client_half_close", GECXTerminalReason.CLIENT_HALF_CLOSE),
+            ("gateway_shutdown", GECXTerminalReason.EXPLICIT_SHUTDOWN),
+        ],
+    )
+    def test_gateway_cleanup_is_silent(self, connector, gateway_reason, terminal_reason):
+        session = self._session(connector)
+        connector.streaming_sessions["conv-1"] = session
+
+        connector.end_conversation(
+            "conv-1", {"termination_reason": gateway_reason}
+        )
+
+        assert session.terminal_decision.reason == terminal_reason
+        assert session.terminal_decision.outcome == GECXTerminalOutcome.SILENT
+        assert session.drain_responses() == []
+        assert "conv-1" not in connector.streaming_sessions
+
 
 class TestAudioFormat:
     def test_resolve_input_format_from_nested_gateway_metadata(self, connector):
@@ -270,6 +526,8 @@ class TestAudioFormat:
 class TestSendMessage:
     def test_send_message_enqueues_audio_and_drains_responses(self, connector):
         stream_session = MagicMock()
+        stream_session.is_terminal = False
+        stream_session.enqueue_audio.return_value = True
         stream_session.drain_responses.return_value = [
             connector.create_response(
                 conversation_id="conv-1",
@@ -295,8 +553,15 @@ class TestSpeechBoundaries:
     def test_declares_streaming_audio_delivery(self, connector):
         assert connector.get_audio_delivery_mode() == "streaming"
 
+    def test_opts_into_client_stream_end_cleanup(self, connector):
+        assert connector.should_cleanup_on_client_stream_end() is True
+
+    def test_opts_into_coalesced_speech_end_response(self, connector):
+        assert connector.should_coalesce_speech_end_with_response() is True
+
     def test_speech_started_resets_turn_completion(self, connector):
         stream_session = MagicMock()
+        stream_session.is_terminal = False
 
         with patch.object(connector, "streaming_sessions", {"conv-1": stream_session}):
             responses = list(
@@ -311,6 +576,7 @@ class TestSpeechBoundaries:
 
     def test_speech_ended_waits_for_and_yields_completed_turn(self, connector):
         stream_session = MagicMock()
+        stream_session.is_terminal = False
         expected = connector.create_response(
             conversation_id="conv-1",
             message_type="audio",

--- a/tests/test_local_audio_connector.py
+++ b/tests/test_local_audio_connector.py
@@ -107,6 +107,12 @@ class TestLocalAudioConnector:
             assert connector.audio_files == mock_config["audio_files"]
             assert connector.audio_recorders == {}
 
+    def test_client_stream_end_cleanup_remains_default_off(self, connector):
+        assert connector.should_cleanup_on_client_stream_end() is False
+
+    def test_speech_end_response_coalescing_remains_default_off(self, connector):
+        assert connector.should_coalesce_speech_end_with_response() is False
+
     def test_init_with_minimal_config(self, mock_config_minimal):
         """Test connector initialization with minimal configuration."""
         with patch('src.connectors.local_audio_connector.AudioConverter'):

--- a/tests/test_main_jwt_interceptor.py
+++ b/tests/test_main_jwt_interceptor.py
@@ -18,7 +18,23 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 # Import after path is set
-from main import create_jwt_interceptor
+from main import create_jwt_interceptor, create_streaming_executor
+
+
+def test_streaming_executor_is_attached_to_process_caller_input():
+    class TestServicer:
+        def ProcessCallerInput(self):
+            return None
+
+    servicer = TestServicer()
+    executor = create_streaming_executor(servicer, max_workers=7)
+    try:
+        assert (
+            servicer.ProcessCallerInput.experimental_thread_pool is executor
+        )
+        assert executor._max_workers == 7
+    finally:
+        executor.shutdown(wait=True)
 
 
 class TestCreateJWTInterceptor:

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -5,6 +5,7 @@ This module tests the gateway server's ability to handle both single responses
 and generator responses from connectors, as well as proper audio input processing.
 """
 
+import grpc
 import pytest
 from unittest.mock import MagicMock, patch, Mock
 from typing import Iterator, Dict, Any
@@ -107,6 +108,43 @@ class TestConversationProcessor:
         assert len(responses) == 1
         assert responses[0].prompts[0].text == "Hello, how can I help you?"
         assert responses[0].prompts[0].audio_content == b"audio_response_bytes"
+
+    def test_initial_escalation_plays_audio_before_transfer(
+        self, processor, mock_router
+    ):
+        wav_audio = bytearray(44 + 8000)
+        wav_audio[:4] = b"RIFF"
+        wav_audio[8:12] = b"WAVE"
+        wav_audio[28:32] = (8000).to_bytes(4, "little")
+        wav_audio[36:40] = b"data"
+        wav_audio[40:44] = (8000).to_bytes(4, "little")
+        audio_response = {
+            "message_type": "audio",
+            "text": "Let me connect you now.",
+            "audio_content": bytes(wav_audio),
+            "barge_in_enabled": False,
+        }
+        terminal_response = {
+            "message_type": "transfer",
+            "text": "",
+            "audio_content": b"",
+            "barge_in_enabled": False,
+        }
+        mock_router.route_request.return_value = iter(
+            [audio_response, terminal_response]
+        )
+        cancel_event = MagicMock()
+        cancel_event.wait.return_value = False
+        processor.set_stream_cancel_event(cancel_event)
+
+        responses = list(processor._start_conversation())
+
+        assert len(responses) == 2
+        assert responses[0].prompts[0].audio_content == bytes(wav_audio)
+        assert responses[0].output_events == []
+        assert responses[1].prompts == []
+        assert [event.event_type for event in responses[1].output_events] == [2]
+        cancel_event.wait.assert_called_once_with(1.0)
 
     def test_process_audio_input_uses_configured_rate_when_wxcc_omits_it(self, mock_router):
         processor = ConversationProcessor(
@@ -211,15 +249,84 @@ class TestConversationProcessor:
         mock_router.should_observe_speech_boundaries.return_value = True
         mock_router.should_coalesce_speech_end_with_response.return_value = True
 
-        with patch("src.core.wxcc_gateway_server.time.sleep") as mock_sleep:
-            responses = list(processor._process_audio_input(mock_audio_input))
+        cancel_event = MagicMock()
+        cancel_event.wait.return_value = False
+        processor.set_stream_cancel_event(cancel_event)
+        responses = list(processor._process_audio_input(mock_audio_input))
 
         assert len(responses) == 2
         assert responses[0].prompts[0].audio_content == wav_audio
         assert [event.event_type for event in responses[0].output_events] == [5]
         assert responses[1].prompts == []
         assert [event.event_type for event in responses[1].output_events] == [2]
-        mock_sleep.assert_called_once_with(1.0)
+        cancel_event.wait.assert_called_once_with(1.0)
+
+    def test_gateway_suppresses_delayed_terminal_after_stream_cancellation(
+        self, processor
+    ):
+        wav_audio = bytearray(44 + 8000)
+        wav_audio[:4] = b"RIFF"
+        wav_audio[8:12] = b"WAVE"
+        wav_audio[28:32] = (8000).to_bytes(4, "little")
+        wav_audio[36:40] = b"data"
+        wav_audio[40:44] = (8000).to_bytes(4, "little")
+        responses = iter(
+            [
+                {
+                    "message_type": "audio",
+                    "text": "Transferring now.",
+                    "audio_content": bytes(wav_audio),
+                },
+                {"message_type": "transfer", "text": "", "audio_content": b""},
+            ]
+        )
+        cancel_event = MagicMock()
+        cancel_event.wait.return_value = True
+        processor.set_stream_cancel_event(cancel_event)
+
+        grpc_responses = list(
+            processor._iter_grpc_connector_responses(
+                responses, delay_terminal_after_audio=True
+            )
+        )
+
+        assert len(grpc_responses) == 1
+        assert grpc_responses[0].prompts[0].audio_content == bytes(wav_audio)
+        cancel_event.wait.assert_called_once_with(1.0)
+
+    def test_gateway_caps_response_derived_terminal_playback_wait(self, processor):
+        wav_audio = bytearray(44 + 8000)
+        wav_audio[:4] = b"RIFF"
+        wav_audio[8:12] = b"WAVE"
+        wav_audio[28:32] = (8000).to_bytes(4, "little")
+        wav_audio[36:40] = b"data"
+        wav_audio[40:44] = (8000).to_bytes(4, "little")
+        cancel_event = MagicMock()
+        cancel_event.wait.return_value = False
+        processor.set_stream_cancel_event(cancel_event)
+        processor.max_terminal_playback_seconds = 0.25
+
+        list(
+            processor._iter_grpc_connector_responses(
+                iter(
+                    [
+                        {
+                            "message_type": "audio",
+                            "text": "Transferring now.",
+                            "audio_content": bytes(wav_audio),
+                        },
+                        {
+                            "message_type": "transfer",
+                            "text": "",
+                            "audio_content": b"",
+                        },
+                    ]
+                ),
+                delay_terminal_after_audio=True,
+            )
+        )
+
+        cancel_event.wait.assert_called_once_with(0.25)
 
     def test_gateway_skips_vad_during_connector_dtmf_mode(
         self, processor, mock_router, mock_audio_input
@@ -1049,6 +1156,48 @@ class TestClientStreamEndCleanup:
         ]
         assert end_calls == []
 
+    def test_reconnection_rejects_virtual_agent_mismatch(self):
+        router = MagicMock(spec=VirtualAgentRouter)
+        router.route_request.side_effect = [self._session_start_response()]
+        router.should_cleanup_on_client_stream_end.return_value = True
+        first_context = MagicMock()
+        first_context.is_active.return_value = True
+        second_context = MagicMock()
+        second_context.is_active.return_value = True
+        server = WxCCGatewayServer(router)
+
+        first_responses = list(
+            server.ProcessCallerInput(
+                iter([self._session_start_request()]), first_context
+            )
+        )
+        mismatched_request = VoiceVARequest(
+            conversation_id="stream-end-conv",
+            virtual_agent_id="Different Agent",
+            event_input=EventInput(
+                event_type=EventInput.EventType.CUSTOM_EVENT,
+                name="continue_call",
+            ),
+        )
+        second_responses = list(
+            server.ProcessCallerInput(iter([mismatched_request]), second_context)
+        )
+
+        assert len(first_responses) == 1
+        assert second_responses == []
+        second_context.set_code.assert_called_once_with(
+            grpc.StatusCode.INVALID_ARGUMENT
+        )
+        assert server.conversations["stream-end-conv"].virtual_agent_id == (
+            "GECX Agent"
+        )
+        start_calls = [
+            call
+            for call in router.route_request.call_args_list
+            if len(call.args) > 1 and call.args[1] == "start_conversation"
+        ]
+        assert len(start_calls) == 1
+
     def test_opted_in_connector_cleans_up_cancelled_stream(self):
         router = MagicMock(spec=VirtualAgentRouter)
         router.route_request.side_effect = [self._session_start_response(), None]
@@ -1062,6 +1211,7 @@ class TestClientStreamEndCleanup:
         )
 
         assert len(responses) == 1
+        router.should_cleanup_on_client_stream_end.assert_called_with("GECX Agent")
         router.route_request.assert_any_call(
             "GECX Agent",
             "end_conversation",

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -9,9 +9,10 @@ import pytest
 from unittest.mock import MagicMock, patch, Mock
 from typing import Iterator, Dict, Any
 
-from src.core.wxcc_gateway_server import ConversationProcessor
+from src.core.wxcc_gateway_server import ConversationProcessor, WxCCGatewayServer
 from src.core.virtual_agent_router import VirtualAgentRouter
-from src.generated.voicevirtualagent_pb2 import VoiceInput
+from src.generated.byova_common_pb2 import EventInput
+from src.generated.voicevirtualagent_pb2 import VoiceInput, VoiceVARequest
 from src.utils.silero_speech_boundary import SpeechBoundarySignal
 
 
@@ -22,6 +23,7 @@ class TestConversationProcessor:
     def mock_router(self):
         """Create a mock router for testing."""
         router = MagicMock(spec=VirtualAgentRouter)
+        router.should_coalesce_speech_end_with_response.return_value = False
         return router
 
     @pytest.fixture
@@ -174,6 +176,51 @@ class TestConversationProcessor:
             "speech_boundary": {"kind": "speech_ended"},
         }
 
+    def test_gateway_coalesces_gecx_speech_end_with_transfer_response(
+        self, processor, mock_router, mock_audio_input
+    ):
+        processor.speech_boundary_observer = MagicMock()
+        processor.speech_boundary_observer.observe.return_value = [
+            SpeechBoundarySignal("speech_ended", "test_conv_123", 8000)
+        ]
+        wav_audio = bytearray(44 + 8000)
+        wav_audio[:4] = b"RIFF"
+        wav_audio[8:12] = b"WAVE"
+        wav_audio[28:32] = (8000).to_bytes(4, "little")
+        wav_audio[36:40] = b"data"
+        wav_audio[40:44] = (8000).to_bytes(4, "little")
+        wav_audio = bytes(wav_audio)
+        audio_response = {
+            "message_type": "audio",
+            "text": "Let me connect you now.",
+            "audio_content": wav_audio,
+            "barge_in_enabled": False,
+            "output_events": [],
+        }
+        transfer_response = {
+            "message_type": "transfer",
+            "text": "",
+            "audio_content": b"",
+            "barge_in_enabled": False,
+            "output_events": [],
+        }
+        mock_router.route_request.side_effect = [
+            None,
+            iter([audio_response, transfer_response]),
+        ]
+        mock_router.should_observe_speech_boundaries.return_value = True
+        mock_router.should_coalesce_speech_end_with_response.return_value = True
+
+        with patch("src.core.wxcc_gateway_server.time.sleep") as mock_sleep:
+            responses = list(processor._process_audio_input(mock_audio_input))
+
+        assert len(responses) == 2
+        assert responses[0].prompts[0].audio_content == wav_audio
+        assert [event.event_type for event in responses[0].output_events] == [5]
+        assert responses[1].prompts == []
+        assert [event.event_type for event in responses[1].output_events] == [2]
+        mock_sleep.assert_called_once_with(1.0)
+
     def test_gateway_skips_vad_during_connector_dtmf_mode(
         self, processor, mock_router, mock_audio_input
     ):
@@ -218,7 +265,7 @@ class TestConversationProcessor:
         mock_response = {
             "message_type": "transfer",
             "text": "Let me transfer you to a human agent.",
-            "audio_content": b"",
+            "audio_content": b"ces-transfer-audio",
             "barge_in_enabled": False,
             "response_type": "final"
         }
@@ -231,6 +278,8 @@ class TestConversationProcessor:
         assert len(responses) == 1
         response = responses[0]
         assert response.prompts[0].text == "Let me transfer you to a human agent."
+        assert response.prompts[0].audio_content == b"ces-transfer-audio"
+        assert response.prompts[0].is_barge_in_enabled is False
         
         # Verify TRANSFER_TO_AGENT event was created
         assert len(response.output_events) == 1
@@ -571,6 +620,7 @@ class TestConversationProcessor:
                 "conversation_id": "test_conv_123",
                 "virtual_agent_id": "test_agent_456",
                 "input_type": "conversation_end",
+                "termination_reason": "client_session_end",
             }
         )
 
@@ -616,6 +666,21 @@ class TestConversationProcessor:
         assert len(final_response.output_events) == 1
         assert final_response.output_events[0].event_type == 1  # SESSION_END
         assert final_response.output_events[0].name == "session_ended_by_client"
+
+    def test_cleanup_forwards_termination_reason(self, processor, mock_router):
+        processor.cleanup("client_half_close")
+
+        mock_router.route_request.assert_called_once_with(
+            "test_agent_456",
+            "end_conversation",
+            "test_conv_123",
+            {
+                "conversation_id": "test_conv_123",
+                "virtual_agent_id": "test_agent_456",
+                "input_type": "conversation_end",
+                "termination_reason": "client_half_close",
+            },
+        )
 
     def test_audio_input_field_access(self, processor, mock_router, mock_audio_input):
         """Test that audio input correctly accesses caller_audio field."""
@@ -918,3 +983,143 @@ class TestConversationProcessor:
         # Verify metadata is empty protobuf Struct (protobuf default for message fields)
         assert event.metadata is not None
         # In protobuf, message fields can't be None, they default to empty message
+
+
+class TestClientStreamEndCleanup:
+    @staticmethod
+    def _session_start_request():
+        return VoiceVARequest(
+            conversation_id="stream-end-conv",
+            virtual_agent_id="GECX Agent",
+            event_input=EventInput(
+                event_type=EventInput.EventType.SESSION_START,
+                name="call_start",
+            ),
+        )
+
+    @staticmethod
+    def _session_start_response():
+        return {
+            "message_type": "session_start",
+            "text": "Connected",
+            "audio_content": b"",
+            "barge_in_enabled": False,
+            "response_type": "final",
+        }
+
+    @staticmethod
+    def _custom_event_request():
+        return VoiceVARequest(
+            conversation_id="stream-end-conv",
+            virtual_agent_id="GECX Agent",
+            event_input=EventInput(
+                event_type=EventInput.EventType.CUSTOM_EVENT,
+                name="continue_call",
+            ),
+        )
+
+    def test_opted_in_connector_survives_half_close_and_reconnection(self):
+        router = MagicMock(spec=VirtualAgentRouter)
+        router.route_request.side_effect = [self._session_start_response(), None]
+        router.should_cleanup_on_client_stream_end.return_value = True
+        context = MagicMock()
+        context.is_active.return_value = True
+        server = WxCCGatewayServer(router)
+
+        first_responses = list(
+            server.ProcessCallerInput(iter([self._session_start_request()]), context)
+        )
+        second_responses = list(
+            server.ProcessCallerInput(iter([self._custom_event_request()]), context)
+        )
+
+        assert len(first_responses) == 1
+        assert second_responses == []
+        assert "stream-end-conv" in server.conversations
+        start_calls = [
+            call
+            for call in router.route_request.call_args_list
+            if len(call.args) > 1 and call.args[1] == "start_conversation"
+        ]
+        assert len(start_calls) == 1
+        end_calls = [
+            call
+            for call in router.route_request.call_args_list
+            if len(call.args) > 1 and call.args[1] == "end_conversation"
+        ]
+        assert end_calls == []
+
+    def test_opted_in_connector_cleans_up_cancelled_stream(self):
+        router = MagicMock(spec=VirtualAgentRouter)
+        router.route_request.side_effect = [self._session_start_response(), None]
+        router.should_cleanup_on_client_stream_end.return_value = True
+        context = MagicMock()
+        context.is_active.return_value = False
+        server = WxCCGatewayServer(router)
+
+        responses = list(
+            server.ProcessCallerInput(iter([self._session_start_request()]), context)
+        )
+
+        assert len(responses) == 1
+        router.route_request.assert_any_call(
+            "GECX Agent",
+            "end_conversation",
+            "stream-end-conv",
+            {
+                "conversation_id": "stream-end-conv",
+                "virtual_agent_id": "GECX Agent",
+                "input_type": "conversation_end",
+                "termination_reason": "client_cancelled",
+            },
+        )
+        assert "stream-end-conv" not in server.conversations
+
+    def test_opted_in_connector_cleans_up_request_stream_error(self):
+        router = MagicMock(spec=VirtualAgentRouter)
+        router.route_request.side_effect = [self._session_start_response(), None]
+        router.should_cleanup_on_client_stream_end.return_value = True
+        context = MagicMock()
+        context.is_active.return_value = True
+        server = WxCCGatewayServer(router)
+
+        def failing_requests():
+            yield self._session_start_request()
+            raise RuntimeError("request stream failed")
+
+        responses = list(server.ProcessCallerInput(failing_requests(), context))
+
+        assert len(responses) == 1
+        router.route_request.assert_any_call(
+            "GECX Agent",
+            "end_conversation",
+            "stream-end-conv",
+            {
+                "conversation_id": "stream-end-conv",
+                "virtual_agent_id": "GECX Agent",
+                "input_type": "conversation_end",
+                "termination_reason": "stream_error",
+            },
+        )
+        assert "stream-end-conv" not in server.conversations
+
+    def test_default_connector_behavior_keeps_conversation_for_reconnection(self):
+        router = MagicMock(spec=VirtualAgentRouter)
+        router.route_request.return_value = self._session_start_response()
+        router.should_cleanup_on_client_stream_end.return_value = False
+        context = MagicMock()
+        context.is_active.return_value = True
+        server = WxCCGatewayServer(router)
+
+        responses = list(
+            server.ProcessCallerInput(iter([self._session_start_request()]), context)
+        )
+
+        assert len(responses) == 1
+        assert "stream-end-conv" in server.conversations
+        end_calls = [
+            call
+            for call in router.route_request.call_args_list
+            if len(call.args) > 1 and call.args[1] == "end_conversation"
+        ]
+        assert end_calls == []


### PR DESCRIPTION
## Summary

- add a first-wins GECX terminal lifecycle for normal completion, escalation, timeout, GoAway, cancellation, client stream end, stream errors, and shutdown
- map documented `session_escalated=true` metadata to `TRANSFER_TO_AGENT` while preserving configurable compatibility aliases
- keep CES text with its matching audio, coalesce GECX `END_OF_INPUT` with the completed prompt, and preserve the final CES announcement before emitting the transfer event
- return initial-turn prompt audio and terminal events as separate ordered responses
- derive the announcement playback gate from each CES WAV response, with a configurable safety ceiling and cancellation support
- run bidirectional caller streams on a dedicated executor so playback gating cannot starve health or unary RPCs
- reject conversation reconnections that change the virtual agent and use the stored agent identity for cleanup
- redact terminal metadata values from INFO logs while retaining an explicit DEBUG-only troubleshooting option

## Root cause

CES streams text, audio, and `EndSession` independently. Sending those as separate WxCC responses introduced stream backpressure and duplicate text-to-speech. Sending the transfer event with the audio response made WxCC transfer immediately and skip the prompt. The gateway now keeps each CES turn together, sends the final announcement first, and emits the terminal event after the response-derived audio duration.

## Impact

Explicit CES escalation reliably reaches the WxCC Transfer branch while preserving the CES transfer announcement. Normal terminal paths emit one session-end decision, and client cancellation or stream close performs silent cleanup. Other connectors retain their existing behavior.

No protobuf changes are required. The new gateway capacity and playback-ceiling settings are backward-compatible defaults.

## Validation

- `PYTHONPATH=. venv/bin/pytest -q` — 358 passed
- focused GECX, local connector, gateway, and executor coverage — 140 passed
- `venv/bin/pip check` — clean
- changed-file Ruff `F841` check — clean
- `git diff --check` — clean
- review-fix commit `a8698a3` deployed to the private AWS test environment; public health, `ListVirtualAgents`, service status, and both ALB target groups verified healthy