### PR TITLE
fix(gecx): restore response and terminal event ordering

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -186,6 +186,8 @@ connectors:
       turn_response_timeout_seconds: 30
       # Trailing codec silence for reliable CES audio endpoint detection.
       endpointing_silence_ms: 1000
+      input_preroll_ms: 500
+      terminal_response_grace_seconds: 3
       # Omit auth settings to use Application Default Credentials.
       # service_account_key: "/path/to/service-account.json"
       agents:

--- a/config/README.md
+++ b/config/README.md
@@ -184,6 +184,8 @@ connectors:
       output_audio_encoding: "MULAW"
       force_input_format: "wxcc"
       turn_response_timeout_seconds: 30
+      # Trailing codec silence for reliable CES audio endpoint detection.
+      endpointing_silence_ms: 1000
       # Omit auth settings to use Application Default Credentials.
       # service_account_key: "/path/to/service-account.json"
       agents:

--- a/config/config.cloudrun.yaml
+++ b/config/config.cloudrun.yaml
@@ -47,6 +47,8 @@ connectors:
       force_input_format: "wxcc"
       turn_response_timeout_seconds: 30
       endpointing_silence_ms: 1000
+      input_preroll_ms: 500
+      terminal_response_grace_seconds: 3
       agents:
         - "My GECX Agent"
 

--- a/config/config.cloudrun.yaml
+++ b/config/config.cloudrun.yaml
@@ -46,6 +46,7 @@ connectors:
       enable_partial_responses: true
       force_input_format: "wxcc"
       turn_response_timeout_seconds: 30
+      endpointing_silence_ms: 1000
       agents:
         - "My GECX Agent"
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -89,6 +89,9 @@ connectors:
   #     turn_response_timeout_seconds: 30
   #     # Trailing codec silence lets CES reliably endpoint short voice turns.
   #     endpointing_silence_ms: 1000
+  #     # Preserve speech before VAD start and catch delayed EndSession after TTS.
+  #     input_preroll_ms: 500
+  #     terminal_response_grace_seconds: 3
   #     # Omit auth settings to use Application Default Credentials.
   #     # service_account_key: "/path/to/service-account.json"
   #     agents:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -87,6 +87,8 @@ connectors:
   #     enable_partial_responses: true
   #     force_input_format: "wxcc"
   #     turn_response_timeout_seconds: 30
+  #     # Trailing codec silence lets CES reliably endpoint short voice turns.
+  #     endpointing_silence_ms: 1000
   #     # Omit auth settings to use Application Default Credentials.
   #     # service_account_key: "/path/to/service-account.json"
   #     agents:

--- a/config/gecx_example.yaml
+++ b/config/gecx_example.yaml
@@ -41,6 +41,10 @@ gecx_connector:
     turn_response_timeout_seconds: 30
     # Queued after gateway VAD speech end so CES can endpoint short utterances.
     endpointing_silence_ms: 1000
+    # Buffer through gateway VAD end so CES receives one intact caller turn.
+    input_preroll_ms: 500
+    # Some EndSession signals follow the final TTS frames.
+    terminal_response_grace_seconds: 3
 
     # --- Escalation / human handoff -------------------------------------
     # CES signals escalation as an EndSession carrying a metadata Struct. The

--- a/config/gecx_example.yaml
+++ b/config/gecx_example.yaml
@@ -39,6 +39,8 @@ gecx_connector:
     enable_partial_responses: true
     force_input_format: "wxcc"
     turn_response_timeout_seconds: 30
+    # Queued after gateway VAD speech end so CES can endpoint short utterances.
+    endpointing_silence_ms: 1000
 
     # --- Escalation / human handoff -------------------------------------
     # CES signals escalation as an EndSession carrying a metadata Struct. The

--- a/docs/guides/byova-gecx-setup.md
+++ b/docs/guides/byova-gecx-setup.md
@@ -322,6 +322,12 @@ For GECX, the gateway also places `END_OF_INPUT` on that completed response
 instead of sending it as a preceding standalone response; `START_OF_INPUT`
 remains immediate.
 
+Caller audio is buffered from a bounded pre-roll through the gateway's Silero
+speech-end boundary, then sent to CES as one contiguous turn. This prevents a
+natural pause inside an utterance from becoming an unintended CES barge-in.
+After a terminal-sounding response, the connector also allows a short grace
+window for an `EndSession` that follows the final TTS frames.
+
 ## Configuration reference
 
 | Key | Required | Description |
@@ -338,6 +344,9 @@ remains immediate.
 | `enable_partial_responses` | No | Map CES partial outputs to WxCC `PARTIAL` responses |
 | `force_input_format` | No | `wxcc` forces 8 kHz MULAW when input metadata is unavailable |
 | `turn_response_timeout_seconds` | No | Maximum wait after gateway speech end for CES to complete the agent turn (default: `30`) |
+| `endpointing_silence_ms` | No | Codec-correct silence appended to each buffered caller turn for CES endpoint detection (default: `1000`) |
+| `input_preroll_ms` | No | Bounded caller audio retained before gateway speech start to avoid clipping (default: `500`) |
+| `terminal_response_grace_seconds` | No | Wait for delayed `EndSession` after a terminal-sounding TTS turn (default: `3`) |
 | `transfer_metadata_keys` | No | EndSession metadata keys that, when truthy, trigger a human transfer (see [Escalation](#escalation-to-a-human-agent)) |
 | `transfer_reason_keywords` | No | Substrings that, if found in a reason/type metadata value, trigger a transfer |
 | `transfer_reason_metadata_keys` | No | Which metadata keys are scanned for `transfer_reason_keywords` |

--- a/src/connectors/gecx_connector.py
+++ b/src/connectors/gecx_connector.py
@@ -234,6 +234,15 @@ class GECXStreamingSession:
             self.inbound_queue.put(("event", event_name))
         return True
 
+    def end_audio_turn(self) -> bool:
+        """Queue codec-correct trailing silence so CES can endpoint caller audio."""
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                self._log_late_input("audio_end")
+                return False
+            self.inbound_queue.put(_AUDIO_END)
+        return True
+
     def _log_late_input(self, input_type: str) -> None:
         decision = self._terminal_decision
         self.logger.warning(
@@ -469,6 +478,12 @@ class GECXStreamingSession:
             if self.is_terminal:
                 break
             if item is _AUDIO_END:
+                for audio_chunk in self.connector.endpointing_silence_chunks():
+                    if self.is_terminal:
+                        break
+                    yield ces_v1.BidiSessionClientMessage(
+                        realtime_input=ces_v1.SessionInput(audio=audio_chunk)
+                    )
                 continue
             if isinstance(item, tuple):
                 kind, payload = item
@@ -899,6 +914,9 @@ class GECXConnector(IVendorConnector):
         self.turn_response_timeout_seconds = float(
             config.get("turn_response_timeout_seconds", 30.0)
         )
+        self.endpointing_silence_ms = min(
+            5000, max(0, int(config.get("endpointing_silence_ms", 1000)))
+        )
         self.log_raw_terminal_metadata_debug = bool(
             config.get("log_raw_terminal_metadata_debug", False)
         )
@@ -1160,6 +1178,12 @@ class GECXConnector(IVendorConnector):
         if boundary_kind != "speech_ended":
             return
 
+        if stream_session.end_audio_turn():
+            self.logger.info(
+                "[%s] [GECX] Queued %dms endpointing silence after speech end",
+                conversation_id,
+                self.endpointing_silence_ms,
+            )
         _, responses = stream_session.wait_for_turn_responses(
             timeout=self.turn_response_timeout_seconds
         )
@@ -1419,6 +1443,31 @@ class GECXConnector(IVendorConnector):
         return vendor_data
 
     # --- Audio helpers (adapted from Dialogflow CX connector) ---
+
+    def endpointing_silence_chunks(self) -> list[bytes]:
+        """Build 100 ms silence chunks in the configured CES input codec."""
+        remaining_ms = self.endpointing_silence_ms
+        if remaining_ms <= 0:
+            return []
+
+        encoding = self._normalize_encoding_name(self.input_audio_encoding)
+        if encoding == "LINEAR_16":
+            silence_byte = b"\x00"
+            bytes_per_sample = 2
+        elif encoding == "ALAW":
+            silence_byte = b"\xd5"
+            bytes_per_sample = 1
+        else:
+            silence_byte = b"\xff"
+            bytes_per_sample = 1
+
+        chunks: list[bytes] = []
+        while remaining_ms > 0:
+            chunk_ms = min(100, remaining_ms)
+            sample_count = self.input_sample_rate_hertz * chunk_ms // 1000
+            chunks.append(silence_byte * sample_count * bytes_per_sample)
+            remaining_ms -= chunk_ms
+        return chunks
 
     @staticmethod
     def _normalize_encoding_name(encoding: str) -> str:

--- a/src/connectors/gecx_connector.py
+++ b/src/connectors/gecx_connector.py
@@ -134,6 +134,7 @@ class GECXStreamingSession:
         self._stop_event = threading.Event()
         self._stream_started = threading.Event()
         self._turn_completed = threading.Event()
+        self._terminal_event = threading.Event()
         self._stream_error: Optional[str] = None
         self._thread: Optional[threading.Thread] = None
         self._lock = threading.Lock()
@@ -147,6 +148,9 @@ class GECXStreamingSession:
         # prompt makes WxCC synthesize it and blocks the later CES audio/event.
         self._text_buffer: list[str] = []
         self._audio_buffer = bytearray()
+        self._input_lock = threading.Lock()
+        self._input_audio_buffer = bytearray()
+        self._input_turn_active = False
 
     def start(self) -> None:
         """Start the background bidi stream thread."""
@@ -202,14 +206,24 @@ class GECXStreamingSession:
                 )
 
     def enqueue_audio(self, audio_chunk: bytes) -> bool:
-        """Queue an audio chunk for the CES stream."""
+        """Buffer caller audio until gateway VAD closes the complete turn."""
         if not audio_chunk:
             return False
         with self._lifecycle_lock:
             if self._terminal_decision is not None:
                 self._log_late_input("audio")
                 return False
-            self.inbound_queue.put(audio_chunk)
+            with self._input_lock:
+                self._input_audio_buffer.extend(audio_chunk)
+                if not self._input_turn_active:
+                    pre_roll_bytes = self.connector.input_audio_bytes_for_ms(
+                        self.connector.input_preroll_ms
+                    )
+                    if len(self._input_audio_buffer) > pre_roll_bytes:
+                        if pre_roll_bytes:
+                            del self._input_audio_buffer[:-pre_roll_bytes]
+                        else:
+                            self._input_audio_buffer.clear()
         return True
 
     def enqueue_text(self, text: str) -> bool:
@@ -235,11 +249,21 @@ class GECXStreamingSession:
         return True
 
     def end_audio_turn(self) -> bool:
-        """Queue codec-correct trailing silence so CES can endpoint caller audio."""
+        """Flush one gateway-delimited caller turn and endpointing silence."""
         with self._lifecycle_lock:
             if self._terminal_decision is not None:
                 self._log_late_input("audio_end")
                 return False
+            with self._input_lock:
+                turn_audio = bytes(self._input_audio_buffer)
+                self._input_audio_buffer.clear()
+                self._input_turn_active = False
+
+            chunk_bytes = self.connector.input_audio_bytes_for_ms(100)
+            if chunk_bytes <= 0:
+                chunk_bytes = len(turn_audio) or 1
+            for offset in range(0, len(turn_audio), chunk_bytes):
+                self.inbound_queue.put(turn_audio[offset : offset + chunk_bytes])
             self.inbound_queue.put(_AUDIO_END)
         return True
 
@@ -271,6 +295,8 @@ class GECXStreamingSession:
             if self._terminal_decision is not None:
                 self._log_late_input("speech_boundary")
                 return False
+            with self._input_lock:
+                self._input_turn_active = True
             self._turn_completed.clear()
         return True
 
@@ -293,6 +319,11 @@ class GECXStreamingSession:
                     metadata={"timeout_seconds": timeout},
                 )
         return completed, self.drain_responses()
+
+    def wait_for_terminal_responses(self, timeout: float) -> list[Dict[str, Any]]:
+        """Wait briefly for an EndSession that CES emits after TTS completion."""
+        self._terminal_event.wait(timeout=timeout)
+        return self.drain_responses()
 
     def terminate(
         self,
@@ -343,6 +374,9 @@ class GECXStreamingSession:
             self._terminal_decision = decision
             self._stop_event.set()
 
+            with self._input_lock:
+                self._input_audio_buffer.clear()
+                self._input_turn_active = False
             with self._lock:
                 buffered_text = "".join(self._text_buffer)
                 raw_audio = bytes(self._audio_buffer)
@@ -386,6 +420,7 @@ class GECXStreamingSession:
             # Set completion only after the terminal response is visible so a
             # waiter cannot wake and drain the queue too early.
             self._turn_completed.set()
+            self._terminal_event.set()
 
         self.logger.info(
             "gecx_terminal_decision conversation_id=%s session=%s reason=%s "
@@ -917,6 +952,13 @@ class GECXConnector(IVendorConnector):
         self.endpointing_silence_ms = min(
             5000, max(0, int(config.get("endpointing_silence_ms", 1000)))
         )
+        self.input_preroll_ms = min(
+            2000, max(0, int(config.get("input_preroll_ms", 500)))
+        )
+        self.terminal_response_grace_seconds = min(
+            10.0,
+            max(0.0, float(config.get("terminal_response_grace_seconds", 3.0))),
+        )
         self.log_raw_terminal_metadata_debug = bool(
             config.get("log_raw_terminal_metadata_debug", False)
         )
@@ -1184,10 +1226,34 @@ class GECXConnector(IVendorConnector):
                 conversation_id,
                 self.endpointing_silence_ms,
             )
-        _, responses = stream_session.wait_for_turn_responses(
+        completed, responses = stream_session.wait_for_turn_responses(
             timeout=self.turn_response_timeout_seconds
         )
         yield from responses
+        if completed and self._may_have_delayed_terminal(responses):
+            yield from stream_session.wait_for_terminal_responses(
+                timeout=self.terminal_response_grace_seconds
+            )
+
+    @staticmethod
+    def _may_have_delayed_terminal(responses: list[Dict[str, Any]]) -> bool:
+        """Return whether a completed prompt likely precedes CES EndSession."""
+        response_text = " ".join(
+            str(response.get("text", "")).lower()
+            for response in responses
+            if isinstance(response, dict)
+        )
+        terminal_cues = (
+            "goodbye",
+            "great day",
+            "good day",
+            "take care",
+            "connect you",
+            "transfer",
+            "human agent",
+            "live agent",
+        )
+        return any(cue in response_text for cue in terminal_cues)
 
     def get_available_agents(self) -> list:
         return self.agents
@@ -1443,6 +1509,21 @@ class GECXConnector(IVendorConnector):
         return vendor_data
 
     # --- Audio helpers (adapted from Dialogflow CX connector) ---
+
+    def input_audio_bytes_for_ms(self, duration_ms: int) -> int:
+        """Return encoded input bytes representing the requested duration."""
+        bytes_per_sample = (
+            2
+            if self._normalize_encoding_name(self.input_audio_encoding)
+            == "LINEAR_16"
+            else 1
+        )
+        return (
+            self.input_sample_rate_hertz
+            * max(0, duration_ms)
+            * bytes_per_sample
+            // 1000
+        )
 
     def endpointing_silence_chunks(self) -> list[bytes]:
         """Build 100 ms silence chunks in the configured CES input codec."""

--- a/src/core/wxcc_gateway_server.py
+++ b/src/core/wxcc_gateway_server.py
@@ -301,13 +301,18 @@ class ConversationProcessor:
 
                     if has_terminal_response:
                         self.logger.info(
-                            "Coalescing END_OF_INPUT with terminal connector "
-                            "response for conversation %s",
+                            "Emitting END_OF_INPUT before %d terminal connector "
+                            "response(s) for conversation %s",
+                            len(boundary_responses),
                             self.conversation_id,
                         )
+                        response = self._convert_connector_response_to_grpc(
+                            boundary_connector_response
+                        )
+                        if response is not None:
+                            yield response
                         yield from self._iter_grpc_connector_responses(
                             boundary_responses,
-                            additional_output_event=boundary_event,
                             delay_terminal_after_audio=True,
                         )
                     else:

--- a/src/core/wxcc_gateway_server.py
+++ b/src/core/wxcc_gateway_server.py
@@ -1332,6 +1332,15 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
                 # Track message event
                 self.add_connection_event("message", conversation_id, agent_id)
 
+                if processor.can_be_deleted:
+                    stream_end_reason = "server_terminal"
+                    self.logger.info(
+                        "Completing WxCC response stream after terminal response "
+                        "for conversation %s",
+                        conversation_id,
+                    )
+                    break
+
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.CANCELLED:
                 stream_end_reason = "client_cancelled"
@@ -1359,7 +1368,8 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
                 processor = self.conversations[conversation_id]
                 agent_id = processor.virtual_agent_id
                 cleanup_on_stream_end = (
-                    stream_end_reason != "client_half_close"
+                    not processor.can_be_deleted
+                    and stream_end_reason != "client_half_close"
                     and self.router.should_cleanup_on_client_stream_end(agent_id)
                     is True
                 )

--- a/src/core/wxcc_gateway_server.py
+++ b/src/core/wxcc_gateway_server.py
@@ -282,21 +282,49 @@ class ConversationProcessor:
                     },
                 )
                 if coalesce_speech_end:
-                    coalesced_responses = list(
-                        self._iter_grpc_connector_responses(
-                            boundary_response,
+                    is_iterator = (
+                        hasattr(boundary_response, "__iter__")
+                        and not isinstance(boundary_response, (dict, str, bytes))
+                    )
+                    if is_iterator:
+                        boundary_responses = list(boundary_response)
+                    elif boundary_response is None:
+                        boundary_responses = []
+                    else:
+                        boundary_responses = [boundary_response]
+
+                    has_terminal_response = any(
+                        isinstance(response, dict)
+                        and response.get("message_type") in {"transfer", "session_end"}
+                        for response in boundary_responses
+                    )
+
+                    if has_terminal_response:
+                        self.logger.info(
+                            "Coalescing END_OF_INPUT with terminal connector "
+                            "response for conversation %s",
+                            self.conversation_id,
+                        )
+                        yield from self._iter_grpc_connector_responses(
+                            boundary_responses,
                             additional_output_event=boundary_event,
                             delay_terminal_after_audio=True,
                         )
-                    )
-                    if coalesced_responses:
-                        yield from coalesced_responses
                     else:
+                        self.logger.info(
+                            "Emitting END_OF_INPUT before %d normal connector "
+                            "response(s) for conversation %s",
+                            len(boundary_responses),
+                            self.conversation_id,
+                        )
                         response = self._convert_connector_response_to_grpc(
                             boundary_connector_response
                         )
                         if response is not None:
                             yield response
+                        yield from self._iter_grpc_connector_responses(
+                            boundary_responses
+                        )
                 else:
                     yield from self._iter_grpc_connector_responses(
                         boundary_response, include_single_response=False

--- a/src/core/wxcc_gateway_server.py
+++ b/src/core/wxcc_gateway_server.py
@@ -923,20 +923,29 @@ class ConversationProcessor:
             else:
                 va_response.response_type = VoiceVAResponse.ResponseType.FINAL
 
-            # Set input mode
-            va_response.input_mode = VoiceVAInputMode.INPUT_VOICE_DTMF
-
-            # Set input handling configuration
-            va_response.input_handling_config.CopyFrom(
-                InputHandlingConfig(
-                    dtmf_config=DTMFInputConfig(
-                        dtmf_input_length=1,
-                        inter_digit_timeout_msec=300,
-                        termchar=DTMFDigits.DTMF_DIGIT_POUND,
-                    ),
-                    speech_timers=InputSpeechTimers(complete_timeout_msec=5000),
-                )
+            has_session_end_event = any(
+                event.event_type == OutputEvent.EventType.SESSION_END
+                for event in va_response.output_events
             )
+            if has_session_end_event:
+                # A server-originated SESSION_END is a terminal-only response.
+                # Do not also tell WxCC to collect another voice/DTMF turn.
+                # This matches Cisco's BYOVA reference response shape.
+                self.can_be_deleted = True
+            else:
+                # Set the next input mode and handling configuration only while
+                # the virtual-agent session is still active.
+                va_response.input_mode = VoiceVAInputMode.INPUT_VOICE_DTMF
+                va_response.input_handling_config.CopyFrom(
+                    InputHandlingConfig(
+                        dtmf_config=DTMFInputConfig(
+                            dtmf_input_length=1,
+                            inter_digit_timeout_msec=300,
+                            termchar=DTMFDigits.DTMF_DIGIT_POUND,
+                        ),
+                        speech_timers=InputSpeechTimers(complete_timeout_msec=5000),
+                    )
+                )
 
             self.logger.debug(
                 f"Final gRPC response created with {len(va_response.prompts)} prompts"

--- a/tests/test_gecx_connector.py
+++ b/tests/test_gecx_connector.py
@@ -17,6 +17,7 @@ from src.connectors.gecx_connector import (
     GECXStreamingSession,
     GECXTerminalOutcome,
     GECXTerminalReason,
+    _AUDIO_END,
     _STREAM_STOP,
     _make_ces_session_id,
     _ces_audio_encoding,
@@ -127,6 +128,27 @@ class TestRequestGenerator:
         next(generator)  # Session config is always the first CES message.
         with pytest.raises(StopIteration):
             next(generator)
+
+    def test_audio_end_yields_codec_silence_for_ces_endpointing(self, connector):
+        session = GECXStreamingSession(
+            connector=connector,
+            conversation_id="conv-1",
+            session_path="projects/p/locations/us/apps/a/sessions/s1",
+            deployment_path=connector.deployment_path,
+            initial_message=None,
+        )
+        session.inbound_queue.put(_AUDIO_END)
+        session.inbound_queue.put(_STREAM_STOP)
+
+        generator = session._request_generator()
+        next(generator)  # config
+        endpointing_messages = list(generator)
+
+        assert len(endpointing_messages) == 10
+        assert all(
+            message.realtime_input.audio == b"\xff" * 800
+            for message in endpointing_messages
+        )
 
 
 class TestServerMessageMapping:
@@ -543,6 +565,26 @@ class TestTerminalLifecycle:
 
 
 class TestAudioFormat:
+    @pytest.mark.parametrize(
+        ("encoding", "expected_byte", "expected_chunk_size"),
+        [
+            ("MULAW", b"\xff", 800),
+            ("ALAW", b"\xd5", 800),
+            ("LINEAR16", b"\x00", 1600),
+        ],
+    )
+    def test_endpointing_silence_matches_input_codec(
+        self, connector, encoding, expected_byte, expected_chunk_size
+    ):
+        connector.input_audio_encoding = encoding
+
+        chunks = connector.endpointing_silence_chunks()
+
+        assert len(chunks) == 10
+        assert all(
+            chunk == expected_byte * expected_chunk_size for chunk in chunks
+        )
+
     def test_resolve_input_format_from_nested_gateway_metadata(self, connector):
         rate, encoding = connector._resolve_input_format(
             b"\x00" * 640,
@@ -642,4 +684,5 @@ class TestSpeechBoundaries:
             )
 
         assert responses == [expected]
+        stream_session.end_audio_turn.assert_called_once_with()
         stream_session.wait_for_turn_responses.assert_called_once_with(timeout=30.0)

--- a/tests/test_gecx_connector.py
+++ b/tests/test_gecx_connector.py
@@ -150,6 +150,31 @@ class TestRequestGenerator:
             for message in endpointing_messages
         )
 
+    def test_gateway_vad_flushes_one_intact_buffered_audio_turn(self, connector):
+        connector.input_preroll_ms = 1
+        connector.endpointing_silence_ms = 100
+        session = GECXStreamingSession(
+            connector=connector,
+            conversation_id="conv-1",
+            session_path="projects/p/locations/us/apps/a/sessions/s1",
+            deployment_path=connector.deployment_path,
+            initial_message=None,
+        )
+
+        session.enqueue_audio(b"0123456789")
+        session.begin_input_turn()
+        session.enqueue_audio(b"ABCD")
+        session.end_audio_turn()
+        session.inbound_queue.put(_STREAM_STOP)
+
+        generator = session._request_generator()
+        next(generator)  # config
+        audio_messages = [
+            message.realtime_input.audio for message in generator
+        ]
+
+        assert audio_messages == [b"23456789ABCD", b"\xff" * 800]
+
 
 class TestServerMessageMapping:
     def test_session_output_maps_to_connector_responses(self, connector):
@@ -674,6 +699,7 @@ class TestSpeechBoundaries:
             response_type="final",
         )
         stream_session.wait_for_turn_responses.return_value = (True, [expected])
+        stream_session.wait_for_terminal_responses.return_value = []
 
         with patch.object(connector, "streaming_sessions", {"conv-1": stream_session}):
             responses = list(
@@ -686,3 +712,37 @@ class TestSpeechBoundaries:
         assert responses == [expected]
         stream_session.end_audio_turn.assert_called_once_with()
         stream_session.wait_for_turn_responses.assert_called_once_with(timeout=30.0)
+        stream_session.wait_for_terminal_responses.assert_not_called()
+
+    def test_speech_ended_yields_delayed_terminal_after_agent_audio(
+        self, connector
+    ):
+        stream_session = MagicMock()
+        stream_session.is_terminal = False
+        audio = connector.create_response(
+            conversation_id="conv-1",
+            message_type="audio",
+            text="Alright. Have a great day.",
+            audio_content=b"RIFFaudio",
+            response_type="final",
+        )
+        terminal = connector.create_response(
+            conversation_id="conv-1",
+            message_type="session_end",
+            response_type="final",
+        )
+        stream_session.wait_for_turn_responses.return_value = (True, [audio])
+        stream_session.wait_for_terminal_responses.return_value = [terminal]
+
+        with patch.object(connector, "streaming_sessions", {"conv-1": stream_session}):
+            responses = list(
+                connector.handle_speech_boundary(
+                    "conv-1",
+                    {"speech_boundary": {"kind": "speech_ended"}},
+                )
+            )
+
+        assert responses == [audio, terminal]
+        stream_session.wait_for_terminal_responses.assert_called_once_with(
+            timeout=3.0
+        )

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -252,7 +252,7 @@ class TestConversationProcessor:
         assert responses[1].prompts[0].text == "What dates would you like to book?"
         assert responses[1].output_events == []
 
-    def test_gateway_coalesces_gecx_speech_end_with_transfer_response(
+    def test_gateway_sends_gecx_speech_end_before_transfer_announcement(
         self, processor, mock_router, mock_audio_input
     ):
         processor.speech_boundary_observer = MagicMock()
@@ -292,11 +292,14 @@ class TestConversationProcessor:
         processor.set_stream_cancel_event(cancel_event)
         responses = list(processor._process_audio_input(mock_audio_input))
 
-        assert len(responses) == 2
-        assert responses[0].prompts[0].audio_content == wav_audio
+        assert len(responses) == 3
+        assert responses[0].prompts == []
         assert [event.event_type for event in responses[0].output_events] == [5]
-        assert responses[1].prompts == []
-        assert [event.event_type for event in responses[1].output_events] == [2]
+        assert responses[1].prompts[0].audio_content == wav_audio
+        assert responses[1].prompts[0].text == "Let me connect you now."
+        assert responses[1].output_events == []
+        assert responses[2].prompts == []
+        assert [event.event_type for event in responses[2].output_events] == [2]
         cancel_event.wait.assert_called_once_with(1.0)
 
     def test_gateway_suppresses_delayed_terminal_after_stream_cancellation(

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -214,6 +214,44 @@ class TestConversationProcessor:
             "speech_boundary": {"kind": "speech_ended"},
         }
 
+    def test_gateway_sends_gecx_speech_end_before_normal_prompt(
+        self, processor, mock_router, mock_audio_input
+    ):
+        """Keep a normal GECX prompt separate from END_OF_INPUT."""
+        processor.speech_boundary_observer = MagicMock()
+        processor.speech_boundary_observer.observe.return_value = [
+            SpeechBoundarySignal("speech_ended", "test_conv_123", 8000)
+        ]
+        wav_audio = bytearray(44 + 8000)
+        wav_audio[:4] = b"RIFF"
+        wav_audio[8:12] = b"WAVE"
+        wav_audio[28:32] = (8000).to_bytes(4, "little")
+        wav_audio[36:40] = b"data"
+        wav_audio[40:44] = (8000).to_bytes(4, "little")
+        wav_audio = bytes(wav_audio)
+        audio_response = {
+            "message_type": "audio",
+            "text": "What dates would you like to book?",
+            "audio_content": wav_audio,
+            "barge_in_enabled": False,
+            "output_events": [],
+        }
+        mock_router.route_request.side_effect = [
+            None,
+            iter([audio_response]),
+        ]
+        mock_router.should_observe_speech_boundaries.return_value = True
+        mock_router.should_coalesce_speech_end_with_response.return_value = True
+
+        responses = list(processor._process_audio_input(mock_audio_input))
+
+        assert len(responses) == 2
+        assert responses[0].prompts == []
+        assert [event.event_type for event in responses[0].output_events] == [5]
+        assert responses[1].prompts[0].audio_content == wav_audio
+        assert responses[1].prompts[0].text == "What dates would you like to book?"
+        assert responses[1].output_events == []
+
     def test_gateway_coalesces_gecx_speech_end_with_transfer_response(
         self, processor, mock_router, mock_audio_input
     ):

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -403,6 +403,25 @@ class TestConversationProcessor:
         event = response.output_events[0]
         assert event.event_type == 1  # SESSION_END
         assert event.name == "session_ended"
+        assert response.input_mode == 0  # INPUT_VOICE_MODE_UNSPECIFIED
+        assert not response.HasField("input_handling_config")
+
+    def test_empty_session_end_is_terminal_only_response(self, processor):
+        """SESSION_END must not request another caller input turn."""
+        response = processor._convert_connector_response_to_grpc(
+            {
+                "message_type": "session_end",
+                "text": "",
+                "audio_content": b"",
+                "response_type": "final",
+            }
+        )
+
+        assert response is not None
+        assert [field.name for field, _ in response.ListFields()] == ["output_events"]
+        assert response.output_events[0].event_type == 1  # SESSION_END
+        assert response.output_events[0].name == "session_ended"
+        assert processor.can_be_deleted is True
 
     def test_process_audio_input_with_transfer_to_agent_event(self, processor, mock_router, mock_audio_input):
         """Test processing audio input with TRANSFER_TO_AGENT event from connector."""

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -1182,6 +1182,80 @@ class TestClientStreamEndCleanup:
             ),
         )
 
+    @pytest.mark.parametrize(
+        ("message_type", "expected_event_type"),
+        [("session_end", 1), ("transfer", 2)],
+    )
+    def test_server_terminal_response_completes_stream(
+        self, message_type, expected_event_type
+    ):
+        router = MagicMock(spec=VirtualAgentRouter)
+
+        def route_request(agent_id, operation, conversation_id, message_data):
+            if operation == "start_conversation":
+                return {
+                    "message_type": message_type,
+                    "text": "",
+                    "audio_content": b"",
+                    "response_type": "final",
+                }
+            if operation == "end_conversation":
+                return None
+            raise AssertionError(f"Unexpected operation: {operation}")
+
+        router.route_request.side_effect = route_request
+        router.should_cleanup_on_client_stream_end.return_value = True
+        context = MagicMock()
+        context.is_active.return_value = True
+        server = WxCCGatewayServer(router)
+        consumed_second_request = False
+
+        def requests():
+            nonlocal consumed_second_request
+            yield self._session_start_request()
+            consumed_second_request = True
+            yield self._custom_event_request()
+
+        responses = list(server.ProcessCallerInput(requests(), context))
+
+        assert len(responses) == 1
+        assert responses[0].output_events[0].event_type == expected_event_type
+        assert consumed_second_request is False
+        assert "stream-end-conv" not in server.conversations
+        router.route_request.assert_any_call(
+            "GECX Agent",
+            "end_conversation",
+            "stream-end-conv",
+            {
+                "conversation_id": "stream-end-conv",
+                "virtual_agent_id": "GECX Agent",
+                "input_type": "conversation_end",
+                "termination_reason": "completed",
+            },
+        )
+        router.should_cleanup_on_client_stream_end.assert_not_called()
+
+    def test_nonterminal_response_keeps_request_stream_open(self):
+        router = MagicMock(spec=VirtualAgentRouter)
+        router.route_request.side_effect = [self._session_start_response(), None]
+        router.should_cleanup_on_client_stream_end.return_value = True
+        context = MagicMock()
+        context.is_active.return_value = True
+        server = WxCCGatewayServer(router)
+        consumed_second_request = False
+
+        def requests():
+            nonlocal consumed_second_request
+            yield self._session_start_request()
+            consumed_second_request = True
+            yield self._custom_event_request()
+
+        responses = list(server.ProcessCallerInput(requests(), context))
+
+        assert len(responses) == 1
+        assert consumed_second_request is True
+        assert "stream-end-conv" in server.conversations
+
     def test_opted_in_connector_survives_half_close_and_reconnection(self):
         router = MagicMock(spec=VirtualAgentRouter)
         router.route_request.side_effect = [self._session_start_response(), None]


### PR DESCRIPTION
## Summary

- restore normal GECX prompt delivery after the terminal-session changes
- preserve complete caller audio long enough for CES endpointing
- emit terminal-only session events without an empty prompt response
- complete the WxCC response stream after terminal events
- keep the CES transfer announcement separate from `TRANSFER_TO_AGENT` so both the CES and WxCC announcements play in order

## Why

The prior GECX terminal-session work regressed ordinary prompt delivery and could package a terminal event with the CES announcement. In live calls that either left the caller without a response, left a normally completed call connected, or caused WxCC to transfer before playing the CES announcement.

This PR restores the proven response ordering while retaining reliable normal-end and escalation signaling.

## Validation

- `89` focused GECX and gateway tests passed
- full tracked suite: `368 passed`
- only the existing Python `audioop` deprecation warning remains
- live dev validation passed for:
  - ordinary multi-turn conversation
  - normal completion with the CES goodbye followed by automatic disconnect
  - human escalation with the CES announcement, WxCC announcement, and completed transfer in that order

## Scope

This PR targets `feat/gecx-connector` and deliberately stops at the validated terminal-stability cutoff. Natural-pause/full-duplex ingress and structured turn observability remain on `feat/se-1943-gecx-streaming` for a follow-up PR after the outstanding pause-duration behavior is resolved.

Jira: SE-1943
