### PR TITLE
feat(e2e): add headless natural-pause validation

### DIFF
--- a/tools/byova_e2e/README.md
+++ b/tools/byova_e2e/README.md
@@ -121,6 +121,9 @@ byova-e2e login
 Chrome profile, sign in as the `BYOVA_E2E_TEST_USER_EMAIL` configured in
 `.env`, and approve consent. The local callback must remain
 `http://localhost:8765/oauth/callback`, matching the integration configuration.
+When `BYOVA_E2E_TEST_USER_EMAIL` is set, the authorization request explicitly
+selects an account and supplies that email as the login hint so an existing
+administrator session cannot be accepted accidentally.
 The returned access and refresh tokens are written only to ignored
 `.state/oauth-token.json` with owner-only permissions and refreshed on later
 runs. A temporary `BYOVA_E2E_WEBEX_ACCESS_TOKEN` environment value can instead
@@ -137,6 +140,41 @@ remote speech is observed, the caller injects after 10 seconds by default; set
 artifact records which gate sent the utterance. Run artifacts are written to
 `.artifacts/`; use them with the gateway logs and recordings for post-call
 diagnosis.
+
+### Run a bounded natural-pause scenario
+
+Use repeated `--text-segment` values to render one deterministic caller WAV
+with exact sample-level silence between phrases. The following command inserts
+1.8 seconds of silence: one second for the gateway VAD end-silence threshold
+and 800 ms inside the default one-second GECX resume grace.
+
+```bash
+byova-e2e run \
+  --destination 9999 \
+  --text-segment "I'd like to book" \
+  --text-segment "a room in San Jose" \
+  --segment-pause-ms 1800 \
+  --remote-prompt-occurrence 2 \
+  --require-remote-response \
+  --response-timeout-seconds 30
+```
+
+With `--require-remote-response`, the run fails unless remote audio begins
+after caller injection and subsequently becomes quiet. The artifact records
+the segment count, inserted pause, response observation, and measured response
+latency. It also records UTC receipt time for every browser event plus the
+overall UTC run window, providing an exact interval for gateway and CES log
+correlation. Confirm that both segments formed one CES transcript and one WxCC
+START/END boundary pair.
+
+For Webex Contact Center entry points that play ringback before the virtual
+agent greeting, `--remote-prompt-occurrence 2` waits for the second completed
+remote-audio epoch. This prevents the caller fixture from being injected
+between ringback and creation of the BYOVA conversation.
+
+Live runs use headless Chromium by default, so automated calls do not open a
+browser window over other work. Add `--headed` only when interactive browser
+media debugging is required.
 
 ## Safety boundaries
 

--- a/tools/byova_e2e/src/byova_e2e/audio.py
+++ b/tools/byova_e2e/src/byova_e2e/audio.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import numpy as np
 import soundfile as sf
 
-
 TARGET_SAMPLE_RATE = 16_000
 
 
@@ -27,11 +26,13 @@ class PreparedAudio:
     duration_seconds: float
 
 
-def _write_mono_pcm(source: Path, destination: Path) -> PreparedAudio:
+def _read_mono(source: Path) -> np.ndarray:
     try:
         samples, sample_rate = sf.read(source, dtype="float32", always_2d=True)
     except Exception as error:  # soundfile exposes backend-specific errors
-        raise AudioPreparationError(f"Cannot read WAV input {source}: {error}") from error
+        raise AudioPreparationError(
+            f"Cannot read WAV input {source}: {error}"
+        ) from error
 
     if sample_rate <= 0 or samples.size == 0:
         raise AudioPreparationError(f"WAV input {source} contains no audio")
@@ -40,9 +41,14 @@ def _write_mono_pcm(source: Path, destination: Path) -> PreparedAudio:
     if sample_rate != TARGET_SAMPLE_RATE:
         source_positions = np.arange(len(mono), dtype=np.float64) / sample_rate
         target_length = round(len(mono) * TARGET_SAMPLE_RATE / sample_rate)
-        target_positions = np.arange(target_length, dtype=np.float64) / TARGET_SAMPLE_RATE
+        target_positions = (
+            np.arange(target_length, dtype=np.float64) / TARGET_SAMPLE_RATE
+        )
         mono = np.interp(target_positions, source_positions, mono).astype(np.float32)
+    return mono
 
+
+def _write_samples(mono: np.ndarray, destination: Path) -> PreparedAudio:
     sf.write(destination, mono, TARGET_SAMPLE_RATE, subtype="PCM_16")
     digest = hashlib.sha256(destination.read_bytes()).hexdigest()
     return PreparedAudio(
@@ -50,6 +56,10 @@ def _write_mono_pcm(source: Path, destination: Path) -> PreparedAudio:
         sha256=digest,
         duration_seconds=len(mono) / TARGET_SAMPLE_RATE,
     )
+
+
+def _write_mono_pcm(source: Path, destination: Path) -> PreparedAudio:
+    return _write_samples(_read_mono(source), destination)
 
 
 def prepare_wav(source: Path, destination: Path) -> PreparedAudio:
@@ -60,16 +70,16 @@ def prepare_wav(source: Path, destination: Path) -> PreparedAudio:
     return _write_mono_pcm(source, destination)
 
 
-def render_text(text: str, voice: str, destination: Path) -> PreparedAudio:
-    """Render text with macOS `say` and normalise it for WebRTC playback."""
+def _render_raw_text(text: str, voice: str, raw_path: Path) -> None:
     if not text.strip():
         raise AudioPreparationError("Text input must not be empty")
 
-    raw_path = destination.with_suffix(".say.aiff")
     raw_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         result = subprocess.run(
-            ["say", "-v", voice, "-o", str(raw_path), text], text=True, capture_output=True
+            ["say", "-v", voice, "-o", str(raw_path), text],
+            text=True,
+            capture_output=True,
         )
     except FileNotFoundError as error:
         raise AudioPreparationError(
@@ -78,5 +88,43 @@ def render_text(text: str, voice: str, destination: Path) -> PreparedAudio:
     if result.returncode or not raw_path.is_file() or raw_path.stat().st_size == 0:
         raw_path.unlink(missing_ok=True)
         detail = result.stderr.strip() or f"say exited with status {result.returncode}"
-        raise AudioPreparationError(f"macOS `say` could not render the requested voice: {detail}")
+        raise AudioPreparationError(
+            f"macOS `say` could not render the requested voice: {detail}"
+        )
+
+
+def render_text(text: str, voice: str, destination: Path) -> PreparedAudio:
+    """Render text with macOS `say` and normalise it for WebRTC playback."""
+    raw_path = destination.with_suffix(".say.aiff")
+    _render_raw_text(text, voice, raw_path)
     return _write_mono_pcm(raw_path, destination)
+
+
+def render_text_sequence(
+    segments: list[str],
+    pause_ms: int,
+    voice: str,
+    destination: Path,
+) -> PreparedAudio:
+    """Render speech segments separated by an exact sample-level pause."""
+    if len(segments) < 2:
+        raise AudioPreparationError("A text sequence requires at least two segments")
+    if pause_ms <= 0:
+        raise AudioPreparationError("Sequence pause must be greater than zero")
+
+    rendered: list[np.ndarray] = []
+    for index, segment in enumerate(segments):
+        raw_path = destination.with_name(f"{destination.stem}.segment-{index}.say.aiff")
+        _render_raw_text(segment, voice, raw_path)
+        rendered.append(_read_mono(raw_path))
+
+    silence = np.zeros(
+        round(TARGET_SAMPLE_RATE * pause_ms / 1000),
+        dtype=np.float32,
+    )
+    combined_parts: list[np.ndarray] = []
+    for index, samples in enumerate(rendered):
+        if index:
+            combined_parts.append(silence)
+        combined_parts.append(samples)
+    return _write_samples(np.concatenate(combined_parts), destination)

--- a/tools/byova_e2e/src/byova_e2e/auth.py
+++ b/tools/byova_e2e/src/byova_e2e/auth.py
@@ -16,7 +16,6 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 import requests
 
-
 AUTHORIZE_URL = "https://webexapis.com/v1/authorize"
 TOKEN_URL = "https://webexapis.com/v1/access_token"
 SCOPES = ("spark:xsi", "spark:calls_write", "spark:calls_read", "spark:webrtc_calling")
@@ -34,7 +33,9 @@ def load_local_environment(path: Path) -> None:
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except OSError as error:
-        raise OAuthError(f"Cannot read local environment file {path}: {error}") from error
+        raise OAuthError(
+            f"Cannot read local environment file {path}: {error}"
+        ) from error
 
     for number, raw_line in enumerate(lines, start=1):
         line = raw_line.strip()
@@ -48,8 +49,10 @@ def load_local_environment(path: Path) -> None:
         name = name.strip()
         value = value.strip()
         if not name.startswith("BYOVA_E2E_"):
-            raise OAuthError(f"Only BYOVA_E2E_* variables are allowed in {path}:{number}")
-        if value[:1] in {"\"", "'"} and value[-1:] == value[:1]:
+            raise OAuthError(
+                f"Only BYOVA_E2E_* variables are allowed in {path}:{number}"
+            )
+        if value[:1] in {'"', "'"} and value[-1:] == value[:1]:
             value = value[1:-1]
         os.environ.setdefault(name, value)
 
@@ -63,7 +66,7 @@ class OAuthCredentials:
     redirect_uri: str
 
     @classmethod
-    def from_environment(cls) -> "OAuthCredentials":
+    def from_environment(cls) -> OAuthCredentials:
         missing = [
             name
             for name in ("BYOVA_E2E_WEBEX_CLIENT_ID", "BYOVA_E2E_WEBEX_CLIENT_SECRET")
@@ -93,29 +96,43 @@ class OAuthTokenStore:
         try:
             payload = json.loads(self.path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as error:
-            raise OAuthError(f"Cannot read saved OAuth token at {self.path}: {error}") from error
-        if not isinstance(payload, dict) or not isinstance(payload.get("access_token"), str):
+            raise OAuthError(
+                f"Cannot read saved OAuth token at {self.path}: {error}"
+            ) from error
+        if not isinstance(payload, dict) or not isinstance(
+            payload.get("access_token"), str
+        ):
             raise OAuthError(f"Saved OAuth token at {self.path} is invalid")
         return payload
 
     def save(self, token: dict[str, Any]) -> None:
         self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         temporary = self.path.with_suffix(".tmp")
-        temporary.write_text(json.dumps(token, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        temporary.write_text(
+            json.dumps(token, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
         temporary.chmod(0o600)
         temporary.replace(self.path)
         self.path.chmod(0o600)
 
 
-def authorization_url(credentials: OAuthCredentials, state: str) -> str:
+def authorization_url(
+    credentials: OAuthCredentials,
+    state: str,
+    login_hint: str | None = None,
+) -> str:
     """Return the exact consent URL for the configured local callback."""
-    return f"{AUTHORIZE_URL}?{urlencode({
-        'client_id': credentials.client_id,
-        'response_type': 'code',
-        'redirect_uri': credentials.redirect_uri,
-        'scope': ' '.join(SCOPES),
-        'state': state,
-    })}"
+    parameters = {
+        "client_id": credentials.client_id,
+        "response_type": "code",
+        "redirect_uri": credentials.redirect_uri,
+        "scope": " ".join(SCOPES),
+        "state": state,
+    }
+    if login_hint:
+        parameters["prompt"] = "select_account"
+        parameters["login_hint"] = login_hint
+    return f"{AUTHORIZE_URL}?{urlencode(parameters)}"
 
 
 def exchange_code(credentials: OAuthCredentials, code: str) -> dict[str, Any]:
@@ -157,7 +174,9 @@ def access_token_for_run(store: OAuthTokenStore) -> str:
         return str(token["access_token"])
     refresh = token.get("refresh_token")
     if not isinstance(refresh, str) or not refresh:
-        raise OAuthError("Saved OAuth token has expired and has no refresh token; run `byova-e2e login`")
+        raise OAuthError(
+            "Saved OAuth token has expired and has no refresh token; run `byova-e2e login`"
+        )
     refreshed = refresh_token(OAuthCredentials.from_environment(), refresh)
     store.save(refreshed)
     return str(refreshed["access_token"])
@@ -170,8 +189,16 @@ def complete_login(store: OAuthTokenStore, timeout_seconds: float) -> str:
     state = secrets.token_urlsafe(32)
     callback.start()
     try:
-        print("Open this URL in the WxCC Admin Chrome profile and sign in as the dedicated Webex Calling test user:\n")
-        print(authorization_url(credentials, state))
+        print(
+            "Open this URL in the WxCC Admin Chrome profile and sign in as the dedicated Webex Calling test user:\n"
+        )
+        print(
+            authorization_url(
+                credentials,
+                state,
+                os.environ.get("BYOVA_E2E_TEST_USER_EMAIL"),
+            )
+        )
         code = callback.wait_for_code(state, timeout_seconds)
         store.save(exchange_code(credentials, code))
         return str(store.path)
@@ -200,11 +227,15 @@ class OAuthCallbackServer:
         if parsed.scheme != "http" or parsed.hostname not in {"localhost", "127.0.0.1"}:
             raise OAuthError("OAuth redirect URI must be an http localhost callback")
         if not parsed.port or parsed.path != "/oauth/callback":
-            raise OAuthError("OAuth redirect URI must use /oauth/callback and an explicit port")
+            raise OAuthError(
+                "OAuth redirect URI must use /oauth/callback and an explicit port"
+            )
         self._expected_path = parsed.path
         self._result: dict[str, str] = {}
         self._received = threading.Event()
-        self._httpd = ThreadingHTTPServer((parsed.hostname, parsed.port), self._handler_type())
+        self._httpd = ThreadingHTTPServer(
+            (parsed.hostname, parsed.port), self._handler_type()
+        )
         self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
 
     def start(self) -> None:
@@ -219,7 +250,9 @@ class OAuthCallbackServer:
         if not self._received.wait(timeout_seconds):
             raise OAuthError("Timed out waiting for the OAuth callback")
         if self._result.get("state") != expected_state:
-            raise OAuthError("OAuth callback state did not match the authorization request")
+            raise OAuthError(
+                "OAuth callback state did not match the authorization request"
+            )
         if error := self._result.get("error"):
             raise OAuthError(f"Webex OAuth authorization failed: {error}")
         if code := self._result.get("code"):

--- a/tools/byova_e2e/src/byova_e2e/cli.py
+++ b/tools/byova_e2e/src/byova_e2e/cli.py
@@ -9,11 +9,21 @@ import tempfile
 from pathlib import Path
 
 from .artifacts import redact_destination, write_artifact
-from .audio import AudioPreparationError, prepare_wav, render_text
-from .auth import OAuthError, OAuthTokenStore, access_token_for_run, complete_login, load_local_environment
+from .audio import (
+    AudioPreparationError,
+    prepare_wav,
+    render_text,
+    render_text_sequence,
+)
+from .auth import (
+    OAuthError,
+    OAuthTokenStore,
+    access_token_for_run,
+    complete_login,
+    load_local_environment,
+)
 from .models import RunConfig
 from .runner import BrowserRunner, RunFailure
-
 
 DESTINATION_PATTERN = re.compile(r"^(?:tel:)?\+?[0-9]{2,20}$")
 TOOL_ROOT = Path(__file__).resolve().parents[2]
@@ -24,16 +34,43 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
 
-    login = commands.add_parser("login", help="Authorize the dedicated Webex Calling test user")
+    login = commands.add_parser(
+        "login", help="Authorize the dedicated Webex Calling test user"
+    )
     login.add_argument("--timeout-seconds", type=float, default=300)
 
-    run = commands.add_parser("run", help="Place one test call and inject one utterance")
-    run.add_argument("--destination", required=True, help="Extension or E.164 number to dial")
+    run = commands.add_parser(
+        "run", help="Place one test call and inject one utterance"
+    )
+    run.add_argument(
+        "--destination", required=True, help="Extension or E.164 number to dial"
+    )
     source = run.add_mutually_exclusive_group(required=True)
     source.add_argument("--text", help="Text rendered locally through macOS say")
     source.add_argument("--wav", type=Path, help="Existing WAV fixture to inject")
+    source.add_argument(
+        "--text-segment",
+        action="append",
+        dest="text_segments",
+        help="Repeat for each locally rendered speech segment",
+    )
     run.add_argument("--voice", default="Samantha", help="macOS say voice for --text")
+    run.add_argument(
+        "--segment-pause-ms",
+        type=int,
+        default=1000,
+        help="Exact silence inserted between repeated --text-segment values",
+    )
     run.add_argument("--remote-silence-ms", type=int, default=750)
+    run.add_argument(
+        "--remote-prompt-occurrence",
+        type=int,
+        default=1,
+        help=(
+            "Inject after this completed remote-audio epoch; use 2 when "
+            "contact-center ringback precedes the virtual-agent greeting"
+        ),
+    )
     run.add_argument(
         "--initial-silence-fallback-seconds",
         type=float,
@@ -43,8 +80,27 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--prompt-timeout-seconds", type=float, default=60)
     run.add_argument("--call-timeout-seconds", type=float, default=120)
     run.add_argument("--post-audio-grace-seconds", type=float, default=5)
+    run.add_argument(
+        "--require-remote-response",
+        action="store_true",
+        help="Fail unless remote audio responds after caller audio finishes",
+    )
+    run.add_argument("--response-timeout-seconds", type=float, default=30)
     run.add_argument("--artifact-dir", type=Path, default=TOOL_ROOT / ".artifacts")
-    run.add_argument("--headless", action="store_true")
+    browser_mode = run.add_mutually_exclusive_group()
+    browser_mode.add_argument(
+        "--headless",
+        action="store_true",
+        dest="headless",
+        help="Run Chromium without opening a visible window (default)",
+    )
+    browser_mode.add_argument(
+        "--headed",
+        action="store_false",
+        dest="headless",
+        help="Open Chromium visibly for interactive media debugging",
+    )
+    run.set_defaults(headless=True)
     return parser
 
 
@@ -55,14 +111,21 @@ def main(argv: list[str] | None = None) -> None:
         if args.command == "login":
             if args.timeout_seconds <= 0:
                 raise CLIError("--timeout-seconds must be greater than zero")
-            token_path = complete_login(OAuthTokenStore(TOKEN_PATH), args.timeout_seconds)
+            token_path = complete_login(
+                OAuthTokenStore(TOKEN_PATH), args.timeout_seconds
+            )
             print(f"Webex OAuth authorization saved locally at {token_path}")
             return
         _run(args)
     except (AudioPreparationError, OAuthError, RunFailure, CLIError) as error:
         if args.command == "run":
             event_history = [
-                {"name": event.name, "timestamp": event.timestamp, "details": event.details}
+                {
+                    "name": event.name,
+                    "timestamp": event.timestamp,
+                    "received_at_utc": event.received_at_utc,
+                    "details": event.details,
+                }
                 for event in getattr(error, "events", [])
             ]
             artifact = write_artifact(
@@ -86,22 +149,52 @@ class CLIError(ValueError):
 
 def _run(args: argparse.Namespace) -> None:
     if not DESTINATION_PATTERN.fullmatch(args.destination):
-        raise CLIError("--destination must be an extension or E.164 number, optionally prefixed with tel:")
+        raise CLIError(
+            "--destination must be an extension or E.164 number, optionally prefixed with tel:"
+        )
     if args.remote_silence_ms <= 0:
         raise CLIError("--remote-silence-ms must be greater than zero")
-    if min(args.prompt_timeout_seconds, args.call_timeout_seconds, args.post_audio_grace_seconds) <= 0:
+    if args.remote_prompt_occurrence <= 0:
+        raise CLIError("--remote-prompt-occurrence must be greater than zero")
+    if (
+        min(
+            args.prompt_timeout_seconds,
+            args.call_timeout_seconds,
+            args.post_audio_grace_seconds,
+            args.response_timeout_seconds,
+        )
+        <= 0
+    ):
         raise CLIError("All timeout values must be greater than zero")
     if args.initial_silence_fallback_seconds < 0:
         raise CLIError("--initial-silence-fallback-seconds cannot be negative")
+    if args.text_segments is not None:
+        if len(args.text_segments) < 2:
+            raise CLIError("Repeat --text-segment at least twice")
+        if args.segment_pause_ms <= 0:
+            raise CLIError("--segment-pause-ms must be greater than zero")
 
     token = access_token_for_run(OAuthTokenStore(TOKEN_PATH))
     with tempfile.TemporaryDirectory(prefix="byova-e2e-") as temp_dir:
         audio_path = Path(temp_dir) / "caller.wav"
-        prepared = (
-            render_text(args.text, args.voice, audio_path)
-            if args.text is not None
-            else prepare_wav(args.wav, audio_path)
-        )
+        if args.text is not None:
+            prepared = render_text(args.text, args.voice, audio_path)
+            audio_profile = {"kind": "text"}
+        elif args.text_segments is not None:
+            prepared = render_text_sequence(
+                args.text_segments,
+                args.segment_pause_ms,
+                args.voice,
+                audio_path,
+            )
+            audio_profile = {
+                "kind": "segmented_text",
+                "segment_count": len(args.text_segments),
+                "segment_pause_ms": args.segment_pause_ms,
+            }
+        else:
+            prepared = prepare_wav(args.wav, audio_path)
+            audio_profile = {"kind": "wav"}
         config = RunConfig(
             destination=args.destination,
             access_token=token,
@@ -113,6 +206,9 @@ def _run(args: argparse.Namespace) -> None:
             prompt_timeout_seconds=args.prompt_timeout_seconds,
             call_timeout_seconds=args.call_timeout_seconds,
             post_audio_grace_seconds=args.post_audio_grace_seconds,
+            remote_prompt_occurrence=args.remote_prompt_occurrence,
+            require_remote_response=args.require_remote_response,
+            response_timeout_seconds=args.response_timeout_seconds,
             headless=args.headless,
         )
         result = BrowserRunner(TOOL_ROOT, config).run()
@@ -124,6 +220,12 @@ def _run(args: argparse.Namespace) -> None:
             "status": "completed",
             "audio_sha256": config.audio_sha256,
             "audio_duration_seconds": config.audio_duration_seconds,
+            "audio_profile": audio_profile,
+            "prompt_profile": {
+                "remote_prompt_occurrence": config.remote_prompt_occurrence,
+                "remote_silence_ms": round(config.remote_silence_seconds * 1000),
+            },
+            "browser_profile": {"headless": config.headless},
             **result,
         },
     )

--- a/tools/byova_e2e/src/byova_e2e/models.py
+++ b/tools/byova_e2e/src/byova_e2e/models.py
@@ -21,6 +21,9 @@ class RunConfig:
     prompt_timeout_seconds: float
     call_timeout_seconds: float
     post_audio_grace_seconds: float
+    remote_prompt_occurrence: int = 1
+    require_remote_response: bool = False
+    response_timeout_seconds: float = 30.0
     headless: bool = False
 
 
@@ -31,3 +34,4 @@ class RunEvent:
     name: str
     timestamp: float
     details: dict[str, Any] = field(default_factory=dict)
+    received_at_utc: str | None = None

--- a/tools/byova_e2e/src/byova_e2e/runner.py
+++ b/tools/byova_e2e/src/byova_e2e/runner.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from contextlib import suppress
 import subprocess
 import time
+from contextlib import suppress
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -35,6 +36,7 @@ class BrowserRunner:
         self.browser_diagnostics: list[str] = []
 
     def run(self) -> dict[str, Any]:
+        started_at_utc = datetime.now(timezone.utc).isoformat()
         static_root = self._build_frontend()
         server = LocalRunServer(static_root, self.config)
         server.start()
@@ -46,25 +48,50 @@ class BrowserRunner:
                 try:
                     browser = playwright.chromium.launch(
                         headless=self.config.headless,
-                        args=["--use-fake-ui-for-media-stream", "--use-fake-device-for-media-stream"],
+                        args=[
+                            "--use-fake-ui-for-media-stream",
+                            "--use-fake-device-for-media-stream",
+                        ],
                     )
                     context = browser.new_context(permissions=["microphone"])
                     page = context.new_page()
-                    page.on("console", lambda message: self._record_console(message.type, message.text))
-                    page.on("pageerror", lambda error: self._record_console("pageerror", str(error)))
+                    page.on(
+                        "console",
+                        lambda message: self._record_console(
+                            message.type, message.text
+                        ),
+                    )
+                    page.on(
+                        "pageerror",
+                        lambda error: self._record_console("pageerror", str(error)),
+                    )
                     page.on("response", self._record_failed_response)
                     page.goto(server.url, wait_until="networkidle")
                     page.click("#start-calling-test")
-                    self._wait_for(server, lambda event: event.name == "frontend_ready", 20)
+                    self._wait_for(
+                        server, lambda event: event.name == "frontend_ready", 20
+                    )
                     self._command(page, "dial")
                     deadline = time.monotonic() + self.config.call_timeout_seconds
                     self._wait_for_established(
                         server,
-                        self._bounded_timeout(self.config.prompt_timeout_seconds, deadline),
+                        self._bounded_timeout(
+                            self.config.prompt_timeout_seconds, deadline
+                        ),
                     )
                     self._wait_for_prompt_end(server, page, deadline)
-                    self._wait_for(server, lambda event: event.name == "injection_finished", self._bounded_timeout(30, deadline))
-                    final_reason = self._finish_call(server, page, deadline)
+                    injection_finished = self._wait_for(
+                        server,
+                        lambda event: event.name == "injection_finished",
+                        self._bounded_timeout(30, deadline),
+                    )
+                    finish_result = self._finish_call(
+                        server,
+                        page,
+                        deadline,
+                        injection_finished,
+                    )
+                    final_reason = str(finish_result["completion_reason"])
                 finally:
                     # A crashed browser can make close() fail. Preserve the original
                     # RunFailure so the CLI can write its diagnostic artifact.
@@ -83,14 +110,27 @@ class BrowserRunner:
                 ) from error
             raise RunFailure(str(error), event_history) from error
         except PlaywrightError as error:
-            raise RunFailure(f"Browser automation failed: {error}", list(self.events)) from error
+            raise RunFailure(
+                f"Browser automation failed: {error}", list(self.events)
+            ) from error
         finally:
             server.close()
 
         return {
+            "started_at_utc": started_at_utc,
+            "finished_at_utc": datetime.now(timezone.utc).isoformat(),
             "completion_reason": final_reason,
+            "remote_response_observed": finish_result["remote_response_observed"],
+            "remote_response_latency_seconds": finish_result[
+                "remote_response_latency_seconds"
+            ],
             "events": [
-                {"name": event.name, "timestamp": event.timestamp, "details": event.details}
+                {
+                    "name": event.name,
+                    "timestamp": event.timestamp,
+                    "received_at_utc": event.received_at_utc,
+                    "details": event.details,
+                }
                 for event in self.events
             ],
         }
@@ -111,9 +151,16 @@ class BrowserRunner:
             raise RunFailure("Frontend build did not create web/dist/index.html")
         return static_root
 
-    def _wait_for_prompt_end(self, server: LocalRunServer, page: Any, call_deadline: float) -> None:
-        gate = PromptGate(self.config.remote_silence_seconds)
-        deadline = min(time.monotonic() + self.config.prompt_timeout_seconds, call_deadline)
+    def _wait_for_prompt_end(
+        self, server: LocalRunServer, page: Any, call_deadline: float
+    ) -> None:
+        gate = PromptGate(
+            self.config.remote_silence_seconds,
+            self.config.remote_prompt_occurrence,
+        )
+        deadline = min(
+            time.monotonic() + self.config.prompt_timeout_seconds, call_deadline
+        )
         fallback_deadline = (
             time.monotonic() + self.config.initial_silence_fallback_seconds
             if self.config.initial_silence_fallback_seconds > 0
@@ -138,7 +185,9 @@ class BrowserRunner:
                 self._command(page, "injectAudio", "initial_silence_fallback")
                 gate.mark_injected()
                 return
-        raise RunFailure("No completed remote prompt was detected before the prompt or call timeout")
+        raise RunFailure(
+            "No completed remote prompt was detected before the prompt or call timeout"
+        )
 
     def _wait_for_established(self, server: LocalRunServer, timeout: float) -> RunEvent:
         deadline = time.monotonic() + timeout
@@ -150,14 +199,40 @@ class BrowserRunner:
                 return event
             if event.name == "disconnect":
                 raise RunFailure("Call disconnected before media was established")
-        raise RunFailure(f"Timed out after {timeout:.1f}s waiting for the call to establish")
+        raise RunFailure(
+            f"Timed out after {timeout:.1f}s waiting for the call to establish"
+        )
 
-    def _finish_call(self, server: LocalRunServer, page: Any, call_deadline: float) -> str:
-        grace_deadline = min(time.monotonic() + self.config.post_audio_grace_seconds, call_deadline)
-        while time.monotonic() < grace_deadline:
-            event = self._next_event(server, min(0.2, grace_deadline - time.monotonic()))
-            if event and event.name == "disconnect":
-                return "remote_disconnect"
+    def _finish_call(
+        self,
+        server: LocalRunServer,
+        page: Any,
+        call_deadline: float,
+        injection_finished: RunEvent,
+    ) -> dict[str, Any]:
+        response_latency: float | None = None
+        if self.config.require_remote_response:
+            response_latency = self._wait_for_remote_response(
+                server,
+                call_deadline,
+                injection_finished,
+            )
+        else:
+            grace_deadline = min(
+                time.monotonic() + self.config.post_audio_grace_seconds,
+                call_deadline,
+            )
+            while time.monotonic() < grace_deadline:
+                event = self._next_event(
+                    server,
+                    min(0.2, grace_deadline - time.monotonic()),
+                )
+                if event and event.name == "disconnect":
+                    return {
+                        "completion_reason": "remote_disconnect",
+                        "remote_response_observed": False,
+                        "remote_response_latency_seconds": None,
+                    }
         self._command(page, "endCall")
         try:
             self._wait_for(
@@ -165,11 +240,62 @@ class BrowserRunner:
                 lambda event: event.name == "disconnect",
                 self._bounded_timeout(15, call_deadline),
             )
-            return "caller_disconnect"
+            completion_reason = "caller_disconnect"
         except RunFailure as error:
             if "Timed out" not in str(error):
                 raise
-            return "caller_end_requested"
+            completion_reason = "caller_end_requested"
+        return {
+            "completion_reason": completion_reason,
+            "remote_response_observed": response_latency is not None,
+            "remote_response_latency_seconds": response_latency,
+        }
+
+    def _wait_for_remote_response(
+        self,
+        server: LocalRunServer,
+        call_deadline: float,
+        injection_finished: RunEvent,
+    ) -> float:
+        deadline = min(
+            time.monotonic() + self.config.response_timeout_seconds,
+            call_deadline,
+        )
+        first_active: RunEvent | None = None
+        quiet_since: float | None = None
+        while time.monotonic() < deadline:
+            event = self._next_event(
+                server,
+                min(0.2, deadline - time.monotonic()),
+            )
+            now = time.monotonic()
+            if event is not None:
+                if event.name == "disconnect":
+                    raise RunFailure(
+                        "Call disconnected before the required remote response"
+                    )
+                if event.name == "remote_audio_active":
+                    if first_active is None:
+                        first_active = event
+                    quiet_since = None
+                elif event.name == "remote_audio_inactive" and first_active:
+                    quiet_since = now
+            if (
+                first_active is not None
+                and quiet_since is not None
+                and now - quiet_since >= self.config.remote_silence_seconds
+            ):
+                return max(
+                    0.0,
+                    first_active.timestamp - injection_finished.timestamp,
+                )
+        if first_active is None:
+            raise RunFailure(
+                "No remote response was observed after caller audio finished"
+            )
+        raise RunFailure(
+            "Remote response did not become quiet before the response timeout"
+        )
 
     @staticmethod
     def _bounded_timeout(requested: float, deadline: float) -> float:
@@ -187,7 +313,9 @@ class BrowserRunner:
         except PlaywrightError as error:
             raise RunFailure(f"Browser command {command!r} failed: {error}") from error
 
-    def _wait_for(self, server: LocalRunServer, predicate: Any, timeout: float) -> RunEvent:
+    def _wait_for(
+        self, server: LocalRunServer, predicate: Any, timeout: float
+    ) -> RunEvent:
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             event = self._next_event(server, min(0.2, deadline - time.monotonic()))

--- a/tools/byova_e2e/src/byova_e2e/server.py
+++ b/tools/byova_e2e/src/byova_e2e/server.py
@@ -6,6 +6,7 @@ import json
 import queue
 import threading
 import time
+from datetime import datetime, timezone
 from http import HTTPStatus
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -80,6 +81,7 @@ class LocalRunServer:
                         name=str(payload["name"]),
                         timestamp=float(payload.get("timestamp", time.monotonic())),
                         details=dict(payload.get("details", {})),
+                        received_at_utc=datetime.now(timezone.utc).isoformat(),
                     )
                 except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
                     self.send_error(HTTPStatus.BAD_REQUEST, str(error))

--- a/tools/byova_e2e/src/byova_e2e/state.py
+++ b/tools/byova_e2e/src/byova_e2e/state.py
@@ -10,9 +10,11 @@ class PromptGate:
     """Release one caller utterance after remote audio has gone quiet."""
 
     silence_seconds: float
+    target_prompt_occurrence: int = 1
     remote_activity_observed: bool = False
     remote_active: bool = False
     quiet_since: float | None = None
+    completed_prompt_count: int = 0
     injected: bool = False
 
     def remote_audio_active(self) -> None:
@@ -26,13 +28,18 @@ class PromptGate:
             self.quiet_since = now
 
     def ready_to_inject(self, now: float) -> bool:
-        return (
+        completed = (
             not self.injected
             and self.remote_activity_observed
             and not self.remote_active
             and self.quiet_since is not None
             and now - self.quiet_since >= self.silence_seconds
         )
+        if not completed:
+            return False
+        self.completed_prompt_count += 1
+        self.quiet_since = None
+        return self.completed_prompt_count >= self.target_prompt_occurrence
 
     def mark_injected(self) -> None:
         self.injected = True

--- a/tools/byova_e2e/tests/test_audio.py
+++ b/tools/byova_e2e/tests/test_audio.py
@@ -1,8 +1,13 @@
 import numpy as np
-import soundfile as sf
 import pytest
-
-from byova_e2e.audio import AudioPreparationError, TARGET_SAMPLE_RATE, prepare_wav, render_text
+import soundfile as sf
+from byova_e2e.audio import (
+    TARGET_SAMPLE_RATE,
+    AudioPreparationError,
+    prepare_wav,
+    render_text,
+    render_text_sequence,
+)
 
 
 def test_prepare_wav_downmixes_and_resamples(tmp_path) -> None:
@@ -36,9 +41,35 @@ def test_render_text_normalises_macos_say_output(tmp_path, monkeypatch) -> None:
 
 def test_render_text_reports_macos_say_failure(tmp_path, monkeypatch) -> None:
     def failed_say(command, **_kwargs):
-        return __import__("subprocess").CompletedProcess(command, 1, "", "Unknown voice")
+        return __import__("subprocess").CompletedProcess(
+            command, 1, "", "Unknown voice"
+        )
 
     monkeypatch.setattr("byova_e2e.audio.subprocess.run", failed_say)
 
     with pytest.raises(AudioPreparationError, match="could not render"):
         render_text("test", "unknown", tmp_path / "caller.wav")
+
+
+def test_render_text_sequence_inserts_exact_pause(tmp_path, monkeypatch) -> None:
+    def fake_say(command, **_kwargs):
+        output = command[command.index("-o") + 1]
+        sf.write(output, np.ones(8_000), 8_000, format="AIFF", subtype="PCM_16")
+        return __import__("subprocess").CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr("byova_e2e.audio.subprocess.run", fake_say)
+    prepared = render_text_sequence(
+        ["I'd like to book", "a room in San Jose"],
+        1800,
+        "Samantha",
+        tmp_path / "caller.wav",
+    )
+
+    samples, sample_rate = sf.read(prepared.path, dtype="float32")
+    first_segment_end = TARGET_SAMPLE_RATE
+    second_segment_start = first_segment_end + round(TARGET_SAMPLE_RATE * 1.8)
+
+    assert sample_rate == TARGET_SAMPLE_RATE
+    assert prepared.duration_seconds == pytest.approx(3.8)
+    assert np.max(np.abs(samples[first_segment_end:second_segment_start])) == 0
+    assert np.max(np.abs(samples[second_segment_start:])) > 0

--- a/tools/byova_e2e/tests/test_auth.py
+++ b/tools/byova_e2e/tests/test_auth.py
@@ -3,9 +3,9 @@ import stat
 from urllib.parse import parse_qs, urlparse
 
 from byova_e2e.auth import (
+    SCOPES,
     OAuthCredentials,
     OAuthTokenStore,
-    SCOPES,
     access_token_for_run,
     authorization_url,
     load_local_environment,
@@ -13,7 +13,9 @@ from byova_e2e.auth import (
 
 
 def test_authorization_url_has_required_scopes_and_callback() -> None:
-    credentials = OAuthCredentials("client", "secret", "http://localhost:8765/oauth/callback")
+    credentials = OAuthCredentials(
+        "client", "secret", "http://localhost:8765/oauth/callback"
+    )
 
     query = parse_qs(urlparse(authorization_url(credentials, "state-value")).query)
 
@@ -21,6 +23,25 @@ def test_authorization_url_has_required_scopes_and_callback() -> None:
     assert query["redirect_uri"] == ["http://localhost:8765/oauth/callback"]
     assert query["scope"] == [" ".join(SCOPES)]
     assert query["state"] == ["state-value"]
+
+
+def test_authorization_url_selects_configured_test_user() -> None:
+    credentials = OAuthCredentials(
+        "client", "secret", "http://localhost:8765/oauth/callback"
+    )
+
+    query = parse_qs(
+        urlparse(
+            authorization_url(
+                credentials,
+                "state-value",
+                "testcaller@example.com",
+            )
+        ).query
+    )
+
+    assert query["prompt"] == ["select_account"]
+    assert query["login_hint"] == ["testcaller@example.com"]
 
 
 def test_token_store_uses_owner_only_permissions(tmp_path) -> None:
@@ -31,7 +52,9 @@ def test_token_store_uses_owner_only_permissions(tmp_path) -> None:
     assert stat.S_IMODE(store.path.stat().st_mode) == 0o600
 
 
-def test_access_token_environment_override_does_not_touch_store(tmp_path, monkeypatch) -> None:
+def test_access_token_environment_override_does_not_touch_store(
+    tmp_path, monkeypatch
+) -> None:
     store = OAuthTokenStore(tmp_path / "missing.json")
     monkeypatch.setenv("BYOVA_E2E_WEBEX_ACCESS_TOKEN", "override-token")
 
@@ -39,7 +62,9 @@ def test_access_token_environment_override_does_not_touch_store(tmp_path, monkey
     assert not store.path.exists()
 
 
-def test_local_environment_loads_byova_values_without_overriding_shell(tmp_path, monkeypatch) -> None:
+def test_local_environment_loads_byova_values_without_overriding_shell(
+    tmp_path, monkeypatch
+) -> None:
     environment = tmp_path / ".env"
     environment.write_text(
         "BYOVA_E2E_WEBEX_CLIENT_ID=file-client\n"
@@ -63,4 +88,6 @@ def test_local_environment_rejects_unrelated_variables(tmp_path) -> None:
     except Exception as error:
         assert "Only BYOVA_E2E" in str(error)
     else:
-        raise AssertionError("Expected local environment loader to reject unrelated variables")
+        raise AssertionError(
+            "Expected local environment loader to reject unrelated variables"
+        )

--- a/tools/byova_e2e/tests/test_cli.py
+++ b/tools/byova_e2e/tests/test_cli.py
@@ -1,0 +1,17 @@
+from byova_e2e.cli import build_parser
+
+
+def test_live_runs_are_headless_by_default() -> None:
+    args = build_parser().parse_args(
+        ["run", "--destination", "9999", "--text", "hello"]
+    )
+
+    assert args.headless
+
+
+def test_headed_mode_is_an_explicit_debug_opt_in() -> None:
+    args = build_parser().parse_args(
+        ["run", "--destination", "9999", "--text", "hello", "--headed"]
+    )
+
+    assert not args.headless

--- a/tools/byova_e2e/tests/test_runner.py
+++ b/tools/byova_e2e/tests/test_runner.py
@@ -1,11 +1,12 @@
+import time
 from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
-from playwright.sync_api import Error as PlaywrightError
-
-from byova_e2e.models import RunConfig
+from byova_e2e.models import RunConfig, RunEvent
 from byova_e2e.runner import BrowserRunner, RunFailure
+from playwright.sync_api import Error as PlaywrightError
 
 
 class _Server:
@@ -73,7 +74,9 @@ def _config(tmp_path: Path) -> RunConfig:
     )
 
 
-def test_browser_failure_is_reported_without_masking_cleanup_error(tmp_path, monkeypatch) -> None:
+def test_browser_failure_is_reported_without_masking_cleanup_error(
+    tmp_path, monkeypatch
+) -> None:
     server = _Server()
     monkeypatch.setattr("byova_e2e.runner.LocalRunServer", lambda *_args: server)
     monkeypatch.setattr("byova_e2e.runner.sync_playwright", _sync_playwright)
@@ -84,3 +87,41 @@ def test_browser_failure_is_reported_without_masking_cleanup_error(tmp_path, mon
         runner.run()
 
     assert server.closed
+
+
+class _EventServer:
+    def __init__(self, events: list[RunEvent]) -> None:
+        self.events = list(events)
+
+    def next_event(self, _timeout: float) -> RunEvent | None:
+        return self.events.pop(0) if self.events else None
+
+
+def test_required_remote_response_records_latency_and_waits_for_quiet(
+    tmp_path,
+) -> None:
+    config = replace(
+        _config(tmp_path),
+        require_remote_response=True,
+        response_timeout_seconds=1,
+        remote_silence_seconds=0,
+    )
+    runner = BrowserRunner(tmp_path, config)
+    server = _EventServer(
+        [
+            RunEvent("remote_audio_active", 12.5),
+            RunEvent("remote_audio_inactive", 14.0),
+        ]
+    )
+
+    latency = runner._wait_for_remote_response(
+        server,
+        time.monotonic() + 1,
+        RunEvent("injection_finished", 10.0),
+    )
+
+    assert latency == 2.5
+    assert [event.name for event in runner.events] == [
+        "remote_audio_active",
+        "remote_audio_inactive",
+    ]

--- a/tools/byova_e2e/tests/test_server.py
+++ b/tools/byova_e2e/tests/test_server.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+from byova_e2e.models import RunConfig
+from byova_e2e.server import LocalRunServer
+
+
+def _config(tmp_path: Path) -> RunConfig:
+    audio_path = tmp_path / "caller.wav"
+    audio_path.write_bytes(b"RIFF")
+    return RunConfig(
+        destination="9999",
+        access_token="test-token",
+        audio_path=audio_path,
+        audio_sha256="0" * 64,
+        audio_duration_seconds=1,
+        remote_silence_seconds=0.75,
+        initial_silence_fallback_seconds=10,
+        prompt_timeout_seconds=60,
+        call_timeout_seconds=120,
+        post_audio_grace_seconds=5,
+    )
+
+
+def test_browser_event_receives_utc_correlation_timestamp(tmp_path) -> None:
+    static_root = tmp_path / "static"
+    static_root.mkdir()
+    server = LocalRunServer(static_root, _config(tmp_path))
+    server.start()
+    try:
+        request = Request(
+            f"{server.url}api/events",
+            data=json.dumps(
+                {
+                    "name": "injection_finished",
+                    "timestamp": 12.5,
+                    "details": {},
+                }
+            ).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urlopen(request) as response:
+            assert response.status == 204
+
+        event = server.next_event(1)
+    finally:
+        server.close()
+
+    assert event is not None
+    assert event.name == "injection_finished"
+    assert event.timestamp == 12.5
+    assert event.received_at_utc is not None
+    assert event.received_at_utc.endswith("+00:00")

--- a/tools/byova_e2e/tests/test_state.py
+++ b/tools/byova_e2e/tests/test_state.py
@@ -36,3 +36,18 @@ def test_prompt_gate_injects_only_once() -> None:
     gate.mark_injected()
 
     assert not gate.ready_to_inject(20.0)
+
+
+def test_prompt_gate_can_skip_contact_center_ringback() -> None:
+    gate = PromptGate(silence_seconds=0.75, target_prompt_occurrence=2)
+    gate.remote_audio_active()
+    gate.remote_audio_inactive(10.0)
+
+    assert not gate.ready_to_inject(10.75)
+    assert gate.completed_prompt_count == 1
+
+    gate.remote_audio_active()
+    gate.remote_audio_inactive(20.0)
+
+    assert gate.ready_to_inject(20.75)
+    assert gate.completed_prompt_count == 2

--- a/tools/byova_e2e/web/index.html
+++ b/tools/byova_e2e/web/index.html
@@ -10,6 +10,7 @@
       <h1>BYOVA E2E Calling Client</h1>
       <p id="status">Preparing Webex Calling client…</p>
       <button id="start-calling-test" type="button">Start calling test</button>
+      <audio id="remote-audio" autoplay></audio>
     </main>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/tools/byova_e2e/web/src/audio-level.test.ts
+++ b/tools/byova_e2e/web/src/audio-level.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateRms } from "./audio-level";
+
+describe("calculateRms", () => {
+  it("returns zero for digital silence", () => {
+    expect(calculateRms(new Uint8Array([128, 128, 128, 128]))).toBe(0);
+  });
+
+  it("measures non-silent samples", () => {
+    expect(calculateRms(new Uint8Array([0, 128, 255, 128]))).toBeGreaterThan(0.7);
+  });
+});

--- a/tools/byova_e2e/web/src/audio-level.ts
+++ b/tools/byova_e2e/web/src/audio-level.ts
@@ -1,0 +1,8 @@
+export function calculateRms(values: Uint8Array): number {
+  let squaredTotal = 0;
+  for (const value of values) {
+    const sample = (value - 128) / 128;
+    squaredTotal += sample * sample;
+  }
+  return Math.sqrt(squaredTotal / values.length);
+}

--- a/tools/byova_e2e/web/src/main.ts
+++ b/tools/byova_e2e/web/src/main.ts
@@ -1,6 +1,7 @@
 import CallingPackage from "webex/calling";
 import { LocalMicrophoneStream } from "@webex/calling";
 
+import { calculateRms } from "./audio-level";
 import { unwrapDefaultExport } from "./module-interop";
 
 type RunConfig = {
@@ -55,6 +56,7 @@ declare global {
 
 const status = document.querySelector<HTMLParagraphElement>("#status")!;
 const startButton = document.querySelector<HTMLButtonElement>("#start-calling-test")!;
+const remoteAudio = document.querySelector<HTMLAudioElement>("#remote-audio")!;
 
 function updateStatus(message: string): void {
   status.textContent = message;
@@ -90,6 +92,8 @@ class RemoteAudioActivity {
   private readonly values: Uint8Array<ArrayBuffer>;
   private remoteActive = false;
   private animationFrame?: number;
+  private levelWindowStartedAt = performance.now();
+  private maximumRms = 0;
 
   constructor(context: AudioContext, track: MediaStreamTrack) {
     const stream = new MediaStream([track]);
@@ -109,16 +113,18 @@ class RemoteAudioActivity {
   start(): void {
     const observe = () => {
       this.analyser.getByteTimeDomainData(this.values);
-      let squaredTotal = 0;
-      for (const value of this.values) {
-        const sample = (value - 128) / 128;
-        squaredTotal += sample * sample;
-      }
-      const rms = Math.sqrt(squaredTotal / this.values.length);
+      const rms = calculateRms(this.values);
+      this.maximumRms = Math.max(this.maximumRms, rms);
       const active = rms >= 0.012;
       if (active !== this.remoteActive) {
         this.remoteActive = active;
         void report(active ? "remote_audio_active" : "remote_audio_inactive", { rms });
+      }
+      const now = performance.now();
+      if (now - this.levelWindowStartedAt >= 1000) {
+        void report("remote_audio_level", { maximumRms: this.maximumRms });
+        this.levelWindowStartedAt = now;
+        this.maximumRms = 0;
       }
       this.animationFrame = requestAnimationFrame(observe);
     };
@@ -217,9 +223,11 @@ class CallingMediaClient {
       updateStatus("Call established; listening for the remote prompt.");
       void report("established");
     });
-    this.call.on("remote_media", (track) => this.attachRemoteMedia(track));
+    this.call.on("remote_media", (track) => void this.attachRemoteMedia(track));
     this.call.on("disconnect", () => {
       this.observer?.stop();
+      remoteAudio.pause();
+      remoteAudio.srcObject = null;
       updateStatus("Call disconnected.");
       void report("disconnect");
     });
@@ -254,15 +262,23 @@ class CallingMediaClient {
     this.call?.end();
   }
 
-  private attachRemoteMedia(value: unknown): void {
+  private async attachRemoteMedia(value: unknown): Promise<void> {
     if (!(value instanceof MediaStreamTrack)) {
-      void this.reportError(new Error("Calling SDK remote_media event contained no audio track"));
+      await this.reportError(new Error("Calling SDK remote_media event contained no audio track"));
       return;
     }
+    const stream = new MediaStream([value]);
+    remoteAudio.srcObject = stream;
+    await remoteAudio.play();
     this.observer?.stop();
     this.observer = new RemoteAudioActivity(this.audioContext, value);
     this.observer.start();
-    void report("remote_media");
+    await report("remote_media", {
+      audioContextState: this.audioContext.state,
+      enabled: value.enabled,
+      muted: value.muted,
+      readyState: value.readyState,
+    });
   }
 
   private assertReady(): void {


### PR DESCRIPTION
## Summary

- run the BYOVA browser caller in headless Chromium by default, with `--headed` as an explicit debugging mode
- support deterministic segmented caller audio with exact silence between phrases
- wait for a configurable remote-prompt occurrence before injection
- optionally require and time a remote response after caller audio
- improve OAuth account targeting, UTC event correlation, media diagnostics, and run artifacts

## Why

The initial E2E caller could inject one continuous utterance, but it could not exercise a natural pause inside one caller turn or prove that the virtual agent responded afterward. It also opened a visible Chromium window unless headless mode was explicitly requested.

These additions make the caller suitable for unattended regression validation while preserving a visible mode for interactive media debugging.

## User impact

Automated live BYOVA checks can now:

1. place calls without interrupting desktop work;
2. inject multiple speech segments separated by an exact sample-level pause;
3. avoid injecting during contact-center ringback;
4. fail when the remote agent does not respond; and
5. produce UTC-timestamped artifacts for correlation with gateway and provider logs.

## Validation

- `21 passed` — Python E2E tests
- `4 passed` — browser client tests
- browser production build passed
- Ruff check and format check passed
- `git diff --check` passed
- live headless dev call completed with a 1.8-second segmented pause and an observed remote response

The npm install and build continue to report existing warnings from Webex SDK transitive dependencies.
