### PR TITLE
fix(gecx): preserve turns across bounded natural pauses

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -118,6 +118,7 @@ connectors:
       # Trailing codec silence for reliable CES audio endpoint detection.
       endpointing_silence_ms: 1000
       input_preroll_ms: 500
+      input_pause_preroll_ms: 250
       terminal_response_grace_seconds: 3
       # Omit auth settings to use Application Default Credentials.
       # service_account_key: "/path/to/service-account.json"

--- a/config/README.md
+++ b/config/README.md
@@ -116,7 +116,7 @@ connectors:
       force_input_format: "wxcc"
       turn_response_timeout_seconds: 30
       # Trailing codec silence for reliable CES audio endpoint detection.
-      endpointing_silence_ms: 1000
+      endpointing_silence_ms: 2000
       input_preroll_ms: 500
       input_pause_preroll_ms: 250
       terminal_response_grace_seconds: 3

--- a/config/config.cloudrun.yaml
+++ b/config/config.cloudrun.yaml
@@ -23,6 +23,7 @@ voice_activity_detection:
   threshold: 0.5
   start_debounce_ms: 96
   end_silence_ms: 1000
+  speech_end_grace_ms: 500
   fallback_sample_rate_hertz: 8000
 
 connectors:
@@ -48,6 +49,7 @@ connectors:
       turn_response_timeout_seconds: 30
       endpointing_silence_ms: 1000
       input_preroll_ms: 500
+      input_pause_preroll_ms: 250
       terminal_response_grace_seconds: 3
       agents:
         - "My GECX Agent"

--- a/config/config.cloudrun.yaml
+++ b/config/config.cloudrun.yaml
@@ -47,7 +47,7 @@ connectors:
       enable_partial_responses: true
       force_input_format: "wxcc"
       turn_response_timeout_seconds: 30
-      endpointing_silence_ms: 1000
+      endpointing_silence_ms: 2000
       input_preroll_ms: 500
       input_pause_preroll_ms: 250
       terminal_response_grace_seconds: 3

--- a/config/config.cloudrun.yaml
+++ b/config/config.cloudrun.yaml
@@ -23,7 +23,9 @@ voice_activity_detection:
   threshold: 0.5
   start_debounce_ms: 96
   end_silence_ms: 1000
-  speech_end_grace_ms: 500
+  # Combined with end_silence_ms, this accepts natural pauses up to two
+  # seconds while keeping completed-turn latency bounded.
+  speech_end_grace_ms: 1000
   fallback_sample_rate_hertz: 8000
 
 connectors:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,8 +17,10 @@ voice_activity_detection:
   # One second balances natural pauses with responsive turn-taking for
   # utterance-buffered connectors such as AWS Lex.
   end_silence_ms: 1000
-  # GECX can merge speech that resumes shortly after an apparent turn end.
-  speech_end_grace_ms: 500
+  # GECX can merge speech that resumes within one second after an apparent
+  # turn end. Combined with end_silence_ms, this creates a two-second bounded
+  # natural-pause window without holding every completed turn indefinitely.
+  speech_end_grace_ms: 1000
   # Used only when WxCC omits the mandatory audio_input.sample_rate_hertz field.
   fallback_sample_rate_hertz: 8000
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -90,7 +90,7 @@ connectors:
   #     force_input_format: "wxcc"
   #     turn_response_timeout_seconds: 30
   #     # Trailing codec silence lets CES reliably endpoint short voice turns.
-  #     endpointing_silence_ms: 1000
+  #     endpointing_silence_ms: 2000
   #     # Preserve speech before VAD start, merge bounded resumed-speech onset,
   #     # and catch delayed EndSession after TTS.
   #     input_preroll_ms: 500

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,6 +17,8 @@ voice_activity_detection:
   # One second balances natural pauses with responsive turn-taking for
   # utterance-buffered connectors such as AWS Lex.
   end_silence_ms: 1000
+  # GECX can merge speech that resumes shortly after an apparent turn end.
+  speech_end_grace_ms: 500
   # Used only when WxCC omits the mandatory audio_input.sample_rate_hertz field.
   fallback_sample_rate_hertz: 8000
 
@@ -89,8 +91,10 @@ connectors:
   #     turn_response_timeout_seconds: 30
   #     # Trailing codec silence lets CES reliably endpoint short voice turns.
   #     endpointing_silence_ms: 1000
-  #     # Preserve speech before VAD start and catch delayed EndSession after TTS.
+  #     # Preserve speech before VAD start, merge bounded resumed-speech onset,
+  #     # and catch delayed EndSession after TTS.
   #     input_preroll_ms: 500
+  #     input_pause_preroll_ms: 250
   #     terminal_response_grace_seconds: 3
   #     # Omit auth settings to use Application Default Credentials.
   #     # service_account_key: "/path/to/service-account.json"

--- a/config/gecx_example.yaml
+++ b/config/gecx_example.yaml
@@ -40,7 +40,9 @@ gecx_connector:
     force_input_format: "wxcc"
     turn_response_timeout_seconds: 30
     # Queued after gateway VAD speech end so CES can endpoint short utterances.
-    endpointing_silence_ms: 1000
+    # Keep margin above one second; an exact one-second tail can leave a CES
+    # audio turn open until the caller speaks again.
+    endpointing_silence_ms: 2000
     # Buffer through gateway VAD end so CES receives one intact caller turn.
     input_preroll_ms: 500
     # Retain only bounded onset audio when speech resumes during end grace.

--- a/config/gecx_example.yaml
+++ b/config/gecx_example.yaml
@@ -43,6 +43,8 @@ gecx_connector:
     endpointing_silence_ms: 1000
     # Buffer through gateway VAD end so CES receives one intact caller turn.
     input_preroll_ms: 500
+    # Retain only bounded onset audio when speech resumes during end grace.
+    input_pause_preroll_ms: 250
     # Some EndSession signals follow the final TTS frames.
     terminal_response_grace_seconds: 3
 

--- a/docs/guides/byova-gecx-setup.md
+++ b/docs/guides/byova-gecx-setup.md
@@ -206,11 +206,12 @@ The gateway's central Silero observer owns Webex `START_OF_INPUT` and
 `END_OF_INPUT` events. GECX does not run a second local speech detector: every
 caller-audio frame is ingested while CES responses are being produced.
 At an apparent speech end, the gateway holds `END_OF_INPUT` for
-`speech_end_grace_ms` (default: `500`). If speech resumes in that window, GECX
-removes the endpoint-triggering pause, merges up to `input_pause_preroll_ms` of
-the resumed onset, and keeps one CES input turn. Otherwise it commits the
-boundary normally. Configure the observer under the top-level
-`voice_activity_detection` block in `config/config.yaml`.
+`speech_end_grace_ms` (default: `1000`, maximum: `2000`). With the default
+`end_silence_ms` value, this creates a bounded two-second natural-pause window.
+If speech resumes in that window, GECX removes the endpoint-triggering pause,
+merges up to `input_pause_preroll_ms` of the resumed onset, and keeps one CES
+input turn. Otherwise it commits the boundary normally. Configure the observer
+under the top-level `voice_activity_detection` block in `config/config.yaml`.
 
 ### Audio format: WxCC expects a self-describing WAV clip
 

--- a/docs/guides/byova-gecx-setup.md
+++ b/docs/guides/byova-gecx-setup.md
@@ -204,9 +204,12 @@ implemented here.
 
 The gateway's central Silero observer owns Webex `START_OF_INPUT` and
 `END_OF_INPUT` events. GECX does not run a second local speech detector: every
-caller-audio frame is forwarded to CES immediately, and speech-boundary
-notifications are used only to coordinate turn completion and response
-delivery. Configure the observer under the top-level
+caller-audio frame is ingested while CES responses are being produced.
+At an apparent speech end, the gateway holds `END_OF_INPUT` for
+`speech_end_grace_ms` (default: `500`). If speech resumes in that window, GECX
+removes the endpoint-triggering pause, merges up to `input_pause_preroll_ms` of
+the resumed onset, and keeps one CES input turn. Otherwise it commits the
+boundary normally. Configure the observer under the top-level
 `voice_activity_detection` block in `config/config.yaml`.
 
 ### Audio format: WxCC expects a self-describing WAV clip
@@ -346,6 +349,7 @@ window for an `EndSession` that follows the final TTS frames.
 | `turn_response_timeout_seconds` | No | Maximum wait after gateway speech end for CES to complete the agent turn (default: `30`) |
 | `endpointing_silence_ms` | No | Codec-correct silence appended to each buffered caller turn for CES endpoint detection (default: `1000`) |
 | `input_preroll_ms` | No | Bounded caller audio retained before gateway speech start to avoid clipping (default: `500`) |
+| `input_pause_preroll_ms` | No | Maximum onset audio retained while a possible speech end is held, then merged if the caller resumes (default: `250`) |
 | `terminal_response_grace_seconds` | No | Wait for delayed `EndSession` after a terminal-sounding TTS turn (default: `3`) |
 | `transfer_metadata_keys` | No | EndSession metadata keys that, when truthy, trigger a human transfer (see [Escalation](#escalation-to-a-human-agent)) |
 | `transfer_reason_keywords` | No | Substrings that, if found in a reason/type metadata value, trigger a transfer |

--- a/docs/guides/byova-gecx-setup.md
+++ b/docs/guides/byova-gecx-setup.md
@@ -347,7 +347,7 @@ window for an `EndSession` that follows the final TTS frames.
 | `enable_partial_responses` | No | Map CES partial outputs to WxCC `PARTIAL` responses |
 | `force_input_format` | No | `wxcc` forces 8 kHz MULAW when input metadata is unavailable |
 | `turn_response_timeout_seconds` | No | Maximum wait after gateway speech end for CES to complete the agent turn (default: `30`) |
-| `endpointing_silence_ms` | No | Codec-correct silence appended to each buffered caller turn for CES endpoint detection (default: `1000`) |
+| `endpointing_silence_ms` | No | Codec-correct silence appended to each buffered caller turn for CES endpoint detection (default: `2000`; one second may leave a turn open until more audio arrives) |
 | `input_preroll_ms` | No | Bounded caller audio retained before gateway speech start to avoid clipping (default: `500`) |
 | `input_pause_preroll_ms` | No | Maximum onset audio retained while a possible speech end is held, then merged if the caller resumes (default: `250`) |
 | `terminal_response_grace_seconds` | No | Wait for delayed `EndSession` after a terminal-sounding TTS turn (default: `3`) |

--- a/src/connectors/gecx_connector.py
+++ b/src/connectors/gecx_connector.py
@@ -1004,7 +1004,7 @@ class GECXConnector(IVendorConnector):
             config.get("turn_response_timeout_seconds", 30.0)
         )
         self.endpointing_silence_ms = min(
-            5000, max(0, int(config.get("endpointing_silence_ms", 1000)))
+            5000, max(0, int(config.get("endpointing_silence_ms", 2000)))
         )
         self.input_preroll_ms = min(
             2000, max(0, int(config.get("input_preroll_ms", 500)))

--- a/src/connectors/gecx_connector.py
+++ b/src/connectors/gecx_connector.py
@@ -150,7 +150,9 @@ class GECXStreamingSession:
         self._audio_buffer = bytearray()
         self._input_lock = threading.Lock()
         self._input_audio_buffer = bytearray()
+        self._input_resume_buffer = bytearray()
         self._input_turn_active = False
+        self._input_turn_paused = False
 
     def start(self) -> None:
         """Start the background bidi stream thread."""
@@ -214,8 +216,19 @@ class GECXStreamingSession:
                 self._log_late_input("audio")
                 return False
             with self._input_lock:
-                self._input_audio_buffer.extend(audio_chunk)
-                if not self._input_turn_active:
+                if self._input_turn_paused:
+                    self._input_resume_buffer.extend(audio_chunk)
+                    resume_preroll_bytes = self.connector.input_audio_bytes_for_ms(
+                        self.connector.input_pause_preroll_ms
+                    )
+                    if len(self._input_resume_buffer) > resume_preroll_bytes:
+                        if resume_preroll_bytes:
+                            del self._input_resume_buffer[:-resume_preroll_bytes]
+                        else:
+                            self._input_resume_buffer.clear()
+                else:
+                    self._input_audio_buffer.extend(audio_chunk)
+                if not self._input_turn_active and not self._input_turn_paused:
                     pre_roll_bytes = self.connector.input_audio_bytes_for_ms(
                         self.connector.input_preroll_ms
                     )
@@ -224,6 +237,39 @@ class GECXStreamingSession:
                             del self._input_audio_buffer[:-pre_roll_bytes]
                         else:
                             self._input_audio_buffer.clear()
+        return True
+
+    def pause_input_turn(self, silence_ms: int) -> bool:
+        """Hold a possible turn end and remove its endpoint-triggering silence."""
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                self._log_late_input("speech_pause")
+                return False
+            with self._input_lock:
+                if not self._input_turn_active:
+                    return False
+                silence_bytes = self.connector.input_audio_bytes_for_ms(silence_ms)
+                if silence_bytes:
+                    del self._input_audio_buffer[
+                        -min(silence_bytes, len(self._input_audio_buffer)) :
+                    ]
+                self._input_resume_buffer.clear()
+                self._input_turn_paused = True
+        return True
+
+    def resume_input_turn(self) -> bool:
+        """Merge bounded pre-roll from a resumed speech segment into this turn."""
+        with self._lifecycle_lock:
+            if self._terminal_decision is not None:
+                self._log_late_input("speech_resume")
+                return False
+            with self._input_lock:
+                if not self._input_turn_paused:
+                    return False
+                self._input_audio_buffer.extend(self._input_resume_buffer)
+                self._input_resume_buffer.clear()
+                self._input_turn_paused = False
+                self._input_turn_active = True
         return True
 
     def enqueue_text(self, text: str) -> bool:
@@ -256,8 +302,12 @@ class GECXStreamingSession:
                 return False
             with self._input_lock:
                 turn_audio = bytes(self._input_audio_buffer)
+                resume_audio = bytes(self._input_resume_buffer)
                 self._input_audio_buffer.clear()
+                self._input_audio_buffer.extend(resume_audio)
+                self._input_resume_buffer.clear()
                 self._input_turn_active = False
+                self._input_turn_paused = False
 
             chunk_bytes = self.connector.input_audio_bytes_for_ms(100)
             if chunk_bytes <= 0:
@@ -297,6 +347,8 @@ class GECXStreamingSession:
                 return False
             with self._input_lock:
                 self._input_turn_active = True
+                self._input_turn_paused = False
+                self._input_resume_buffer.clear()
             self._turn_completed.clear()
         return True
 
@@ -376,7 +428,9 @@ class GECXStreamingSession:
 
             with self._input_lock:
                 self._input_audio_buffer.clear()
+                self._input_resume_buffer.clear()
                 self._input_turn_active = False
+                self._input_turn_paused = False
             with self._lock:
                 buffered_text = "".join(self._text_buffer)
                 raw_audio = bytes(self._audio_buffer)
@@ -955,6 +1009,9 @@ class GECXConnector(IVendorConnector):
         self.input_preroll_ms = min(
             2000, max(0, int(config.get("input_preroll_ms", 500)))
         )
+        self.input_pause_preroll_ms = min(
+            1000, max(0, int(config.get("input_pause_preroll_ms", 250)))
+        )
         self.terminal_response_grace_seconds = min(
             10.0,
             max(0.0, float(config.get("terminal_response_grace_seconds", 3.0))),
@@ -1195,6 +1252,42 @@ class GECXConnector(IVendorConnector):
         """Send END_OF_INPUT with the completed CES prompt and terminal event."""
         return True
 
+    def should_merge_speech_pauses(self) -> bool:
+        """Keep a caller turn open briefly after gateway VAD reports silence."""
+        return True
+
+    def pause_speech_turn(self, conversation_id: str, silence_ms: int) -> None:
+        """Hold a possible end and strip the silence that triggered gateway VAD."""
+        with self.sessions_lock:
+            stream_session = self.streaming_sessions.get(conversation_id)
+        if stream_session and stream_session.pause_input_turn(silence_ms):
+            self.logger.info(
+                "[%s] [GECX] Holding speech end; removed %dms trailing silence",
+                conversation_id,
+                silence_ms,
+            )
+
+    def resume_speech_turn(self, conversation_id: str) -> None:
+        """Resume the held caller turn with bounded speech-onset pre-roll."""
+        with self.sessions_lock:
+            stream_session = self.streaming_sessions.get(conversation_id)
+        if stream_session and stream_session.resume_input_turn():
+            self.logger.info(
+                "[%s] [GECX] Merged resumed speech into the active caller turn",
+                conversation_id,
+            )
+
+    def commit_speech_turn(self, conversation_id: str) -> None:
+        """Flush a held caller turn before waiting for its CES response."""
+        with self.sessions_lock:
+            stream_session = self.streaming_sessions.get(conversation_id)
+        if stream_session and stream_session.end_audio_turn():
+            self.logger.info(
+                "[%s] [GECX] Queued %dms endpointing silence after speech end",
+                conversation_id,
+                self.endpointing_silence_ms,
+            )
+
     def handle_speech_boundary(
         self, conversation_id: str, message_data: Dict[str, Any]
     ) -> Generator[Dict[str, Any], None, None]:
@@ -1220,12 +1313,8 @@ class GECXConnector(IVendorConnector):
         if boundary_kind != "speech_ended":
             return
 
-        if stream_session.end_audio_turn():
-            self.logger.info(
-                "[%s] [GECX] Queued %dms endpointing silence after speech end",
-                conversation_id,
-                self.endpointing_silence_ms,
-            )
+        if not message_data.get("speech_turn_committed"):
+            self.commit_speech_turn(conversation_id)
         completed, responses = stream_session.wait_for_turn_responses(
             timeout=self.turn_response_timeout_seconds
         )

--- a/src/connectors/i_vendor_connector.py
+++ b/src/connectors/i_vendor_connector.py
@@ -61,6 +61,24 @@ class IVendorConnector(ABC):
         """
         return False
 
+    def should_merge_speech_pauses(self) -> bool:
+        """Return whether gateway VAD pauses may resume the active input turn."""
+        return False
+
+    def pause_speech_turn(
+        self, conversation_id: str, silence_ms: int
+    ) -> None:
+        """Pause an active caller turn before its final boundary is committed."""
+        del conversation_id, silence_ms
+
+    def resume_speech_turn(self, conversation_id: str) -> None:
+        """Resume a caller turn whose pending end boundary was cancelled."""
+        del conversation_id
+
+    def commit_speech_turn(self, conversation_id: str) -> None:
+        """Commit a held caller turn before its response wait begins."""
+        del conversation_id
+
     def handle_speech_boundary(
         self, conversation_id: str, message_data: Dict[str, Any]
     ) -> Optional[Iterator[Optional[Dict[str, Any]]]]:

--- a/src/core/virtual_agent_router.py
+++ b/src/core/virtual_agent_router.py
@@ -216,6 +216,12 @@ class VirtualAgentRouter:
             agent_id
         ).should_coalesce_speech_end_with_response()
 
+    def should_merge_speech_pauses(self, agent_id: str) -> bool:
+        """Return whether the connector merges resumptions before turn flush."""
+        return self.get_connector_for_agent(
+            agent_id
+        ).should_merge_speech_pauses()
+
     def route_request(self, agent_id: str, method: str, *args, **kwargs) -> Any:
         """
         Route a request to the appropriate connector.

--- a/src/core/wxcc_gateway_server.py
+++ b/src/core/wxcc_gateway_server.py
@@ -82,6 +82,7 @@ class ConversationProcessor:
         ] = None
         self._speech_end_lock = threading.Lock()
         self._pending_speech_end_timer: Optional[threading.Timer] = None
+        self._speech_response_pending = False
         self._async_task_count = 0
         vad_settings = dict(vad_config or {})
         self.vad_fallback_sample_rate_hertz = vad_settings.get(
@@ -153,8 +154,8 @@ class ConversationProcessor:
         timer: threading.Timer
 
         def finalize() -> None:
+            owns_response_wait = False
             try:
-                speech_turn_committed = False
                 with self._speech_end_lock:
                     if self._pending_speech_end_timer is not timer:
                         return
@@ -163,8 +164,18 @@ class ConversationProcessor:
                         "commit_speech_turn",
                         self.conversation_id,
                     )
-                    speech_turn_committed = True
                     self._pending_speech_end_timer = None
+                    if not self._speech_response_pending:
+                        self._speech_response_pending = True
+                        owns_response_wait = True
+
+                if not owns_response_wait:
+                    self.logger.info(
+                        "Extended the pending CES caller turn without another "
+                        "WxCC END_OF_INPUT for conversation %s",
+                        self.conversation_id,
+                    )
+                    return
 
                 signal = SpeechBoundarySignal(
                     "speech_ended",
@@ -173,13 +184,15 @@ class ConversationProcessor:
                 )
                 for response in self._process_speech_boundary(
                     signal,
-                    speech_turn_committed=speech_turn_committed,
+                    speech_turn_committed=True,
                 ):
                     sink = self._async_response_sink
                     if sink is None or not sink(response):
                         break
             finally:
                 with self._speech_end_lock:
+                    if owns_response_wait:
+                        self._speech_response_pending = False
                     self._async_task_count = max(0, self._async_task_count - 1)
 
         timer = threading.Timer(self.speech_end_grace_ms / 1000.0, finalize)
@@ -197,6 +210,29 @@ class ConversationProcessor:
             self.conversation_id,
         )
         timer.start()
+
+    def _continue_pending_speech_turn(self) -> bool:
+        """Start another input segment without duplicating the WxCC boundary."""
+        with self._speech_end_lock:
+            if not self._speech_response_pending:
+                return False
+            self.router.route_request(
+                self.virtual_agent_id,
+                "handle_speech_boundary",
+                self.conversation_id,
+                {
+                    "conversation_id": self.conversation_id,
+                    "virtual_agent_id": self.virtual_agent_id,
+                    "input_type": "speech_boundary",
+                    "speech_boundary": {"kind": "speech_started"},
+                },
+            )
+        self.logger.info(
+            "Continued caller speech while the CES response was pending; "
+            "suppressed duplicate WxCC START_OF_INPUT for conversation %s",
+            self.conversation_id,
+        )
+        return True
 
     def process_request(self, request: VoiceVARequest) -> Iterator[VoiceVAResponse]:
         """
@@ -363,6 +399,12 @@ class ConversationProcessor:
                     merges_speech_pauses
                     and signal.kind == "speech_started"
                     and self._resume_pending_speech_end()
+                ):
+                    continue
+                if (
+                    merges_speech_pauses
+                    and signal.kind == "speech_started"
+                    and self._continue_pending_speech_turn()
                 ):
                     continue
                 if merges_speech_pauses and signal.kind == "speech_ended":
@@ -1135,6 +1177,7 @@ class ConversationProcessor:
         with self._speech_end_lock:
             timer = self._pending_speech_end_timer
             self._pending_speech_end_timer = None
+            self._speech_response_pending = False
             self._async_task_count = 0
         if timer is not None:
             timer.cancel()

--- a/src/core/wxcc_gateway_server.py
+++ b/src/core/wxcc_gateway_server.py
@@ -88,8 +88,9 @@ class ConversationProcessor:
         self.vad_fallback_sample_rate_hertz = vad_settings.get(
             "fallback_sample_rate_hertz", 8000
         )
-        self.speech_end_grace_ms = max(
-            0, int(vad_settings.get("speech_end_grace_ms", 500))
+        self.speech_end_grace_ms = min(
+            2000,
+            max(0, int(vad_settings.get("speech_end_grace_ms", 1000))),
         )
         self.speech_boundary_observer = SileroSpeechBoundaryObserver(
             conversation_id,

--- a/src/core/wxcc_gateway_server.py
+++ b/src/core/wxcc_gateway_server.py
@@ -6,9 +6,10 @@ Webex Contact Center and the virtual agent connectors.
 """
 
 import logging
+import queue
 import threading
 import time
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Callable, Dict, Iterator, Optional
 
 import grpc
 
@@ -34,7 +35,10 @@ from src.generated.voicevirtualagent_pb2_grpc import VoiceVirtualAgentServicer
 from .virtual_agent_router import VirtualAgentRouter
 from .health_service import HealthCheckService
 from src.utils.audio_normalizer import normalize_wxcc_audio
-from src.utils.silero_speech_boundary import SileroSpeechBoundaryObserver
+from src.utils.silero_speech_boundary import (
+    SileroSpeechBoundaryObserver,
+    SpeechBoundarySignal,
+)
 
 
 class ConversationProcessor:
@@ -73,16 +77,26 @@ class ConversationProcessor:
             0.0, float(max_terminal_playback_seconds)
         )
         self._stream_cancel_event = threading.Event()
-        vad_settings = vad_config or {}
+        self._async_response_sink: Optional[
+            Callable[[VoiceVAResponse], bool]
+        ] = None
+        self._speech_end_lock = threading.Lock()
+        self._pending_speech_end_timer: Optional[threading.Timer] = None
+        self._async_task_count = 0
+        vad_settings = dict(vad_config or {})
         self.vad_fallback_sample_rate_hertz = vad_settings.get(
             "fallback_sample_rate_hertz", 8000
+        )
+        self.speech_end_grace_ms = max(
+            0, int(vad_settings.get("speech_end_grace_ms", 500))
         )
         self.speech_boundary_observer = SileroSpeechBoundaryObserver(
             conversation_id,
             **{
                 key: value
                 for key, value in vad_settings.items()
-                if key != "fallback_sample_rate_hertz"
+                if key
+                not in {"fallback_sample_rate_hertz", "speech_end_grace_ms"}
             },
         )
 
@@ -93,6 +107,96 @@ class ConversationProcessor:
     def set_stream_cancel_event(self, cancel_event: threading.Event) -> None:
         """Attach the cancellation signal for the active WxCC request stream."""
         self._stream_cancel_event = cancel_event
+
+    def set_async_response_sink(
+        self, response_sink: Callable[[VoiceVAResponse], bool]
+    ) -> None:
+        """Attach the bounded stream queue used by asynchronous boundary work."""
+        self._async_response_sink = response_sink
+
+    def has_async_work(self) -> bool:
+        """Return whether a delayed speech boundary is still being processed."""
+        with self._speech_end_lock:
+            return self._async_task_count > 0
+
+    def _resume_pending_speech_end(self) -> bool:
+        """Cancel a held end boundary and merge resumed speech into the turn."""
+        with self._speech_end_lock:
+            timer = self._pending_speech_end_timer
+            if timer is None:
+                return False
+            self._pending_speech_end_timer = None
+            self._async_task_count = max(0, self._async_task_count - 1)
+            timer.cancel()
+
+        self.router.route_request(
+            self.virtual_agent_id,
+            "resume_speech_turn",
+            self.conversation_id,
+        )
+        self.logger.info(
+            "Merged speech resumed during %dms end grace for conversation %s",
+            self.speech_end_grace_ms,
+            self.conversation_id,
+        )
+        return True
+
+    def _schedule_speech_end(self, sample_rate_hertz: int) -> None:
+        """Hold a speech end so a natural pause can resume the same turn."""
+        self.router.route_request(
+            self.virtual_agent_id,
+            "pause_speech_turn",
+            self.conversation_id,
+            self.speech_boundary_observer.end_silence_ms,
+        )
+
+        timer: threading.Timer
+
+        def finalize() -> None:
+            try:
+                speech_turn_committed = False
+                with self._speech_end_lock:
+                    if self._pending_speech_end_timer is not timer:
+                        return
+                    self.router.route_request(
+                        self.virtual_agent_id,
+                        "commit_speech_turn",
+                        self.conversation_id,
+                    )
+                    speech_turn_committed = True
+                    self._pending_speech_end_timer = None
+
+                signal = SpeechBoundarySignal(
+                    "speech_ended",
+                    self.conversation_id,
+                    sample_rate_hertz,
+                )
+                for response in self._process_speech_boundary(
+                    signal,
+                    speech_turn_committed=speech_turn_committed,
+                ):
+                    sink = self._async_response_sink
+                    if sink is None or not sink(response):
+                        break
+            finally:
+                with self._speech_end_lock:
+                    self._async_task_count = max(0, self._async_task_count - 1)
+
+        timer = threading.Timer(self.speech_end_grace_ms / 1000.0, finalize)
+        timer.daemon = True
+        with self._speech_end_lock:
+            previous = self._pending_speech_end_timer
+            if previous is not None:
+                previous.cancel()
+                self._async_task_count = max(0, self._async_task_count - 1)
+            self._pending_speech_end_timer = timer
+            self._async_task_count += 1
+        self.logger.info(
+            "Holding END_OF_INPUT for %dms speech-resume grace in conversation %s",
+            self.speech_end_grace_ms,
+            self.conversation_id,
+        )
+        timer.start()
 
     def process_request(self, request: VoiceVARequest) -> Iterator[VoiceVAResponse]:
         """
@@ -248,98 +352,118 @@ class ConversationProcessor:
                     event_type,
                     self.conversation_id,
                 )
-                boundary_event = {
-                    "event_type": event_type,
-                    "name": "" if event_type == "START_OF_INPUT" else "end_of_input",
-                }
-                boundary_connector_response = {
-                    "message_type": "silence",
-                    "output_events": [boundary_event],
-                }
-                coalesce_speech_end = (
-                    signal.kind == "speech_ended"
-                    and self.router.should_coalesce_speech_end_with_response(
+                merges_speech_pauses = (
+                    self._async_response_sink is not None
+                    and self.speech_end_grace_ms > 0
+                    and self.router.should_merge_speech_pauses(
                         self.virtual_agent_id
                     )
                 )
-
-                if not coalesce_speech_end:
-                    response = self._convert_connector_response_to_grpc(
-                        boundary_connector_response
-                    )
-                    if response is not None:
-                        yield response
-
-                boundary_response = self.router.route_request(
-                    self.virtual_agent_id,
-                    "handle_speech_boundary",
-                    self.conversation_id,
-                    {
-                        "conversation_id": self.conversation_id,
-                        "virtual_agent_id": self.virtual_agent_id,
-                        "input_type": "speech_boundary",
-                        "speech_boundary": {"kind": signal.kind},
-                    },
-                )
-                if coalesce_speech_end:
-                    is_iterator = (
-                        hasattr(boundary_response, "__iter__")
-                        and not isinstance(boundary_response, (dict, str, bytes))
-                    )
-                    if is_iterator:
-                        boundary_responses = list(boundary_response)
-                    elif boundary_response is None:
-                        boundary_responses = []
-                    else:
-                        boundary_responses = [boundary_response]
-
-                    has_terminal_response = any(
-                        isinstance(response, dict)
-                        and response.get("message_type") in {"transfer", "session_end"}
-                        for response in boundary_responses
-                    )
-
-                    if has_terminal_response:
-                        self.logger.info(
-                            "Emitting END_OF_INPUT before %d terminal connector "
-                            "response(s) for conversation %s",
-                            len(boundary_responses),
-                            self.conversation_id,
-                        )
-                        response = self._convert_connector_response_to_grpc(
-                            boundary_connector_response
-                        )
-                        if response is not None:
-                            yield response
-                        yield from self._iter_grpc_connector_responses(
-                            boundary_responses,
-                            delay_terminal_after_audio=True,
-                        )
-                    else:
-                        self.logger.info(
-                            "Emitting END_OF_INPUT before %d normal connector "
-                            "response(s) for conversation %s",
-                            len(boundary_responses),
-                            self.conversation_id,
-                        )
-                        response = self._convert_connector_response_to_grpc(
-                            boundary_connector_response
-                        )
-                        if response is not None:
-                            yield response
-                        yield from self._iter_grpc_connector_responses(
-                            boundary_responses
-                        )
-                else:
-                    yield from self._iter_grpc_connector_responses(
-                        boundary_response, include_single_response=False
-                    )
+                if (
+                    merges_speech_pauses
+                    and signal.kind == "speech_started"
+                    and self._resume_pending_speech_end()
+                ):
+                    continue
+                if merges_speech_pauses and signal.kind == "speech_ended":
+                    self._schedule_speech_end(signal.sample_rate_hertz)
+                    continue
+                yield from self._process_speech_boundary(signal)
 
         except Exception as e:
             self.logger.error(
                 f"Error processing audio input for conversation {self.conversation_id}: {e}"
             )
             yield self._create_error_response(f"Audio processing error: {str(e)}")
+
+    def _process_speech_boundary(
+        self,
+        signal: SpeechBoundarySignal,
+        *,
+        speech_turn_committed: bool = False,
+    ) -> Iterator[VoiceVAResponse]:
+        """Commit one gateway speech boundary and convert connector responses."""
+        event_type = (
+            "START_OF_INPUT"
+            if signal.kind == "speech_started"
+            else "END_OF_INPUT"
+        )
+        boundary_event = {
+            "event_type": event_type,
+            "name": "" if event_type == "START_OF_INPUT" else "end_of_input",
+        }
+        boundary_connector_response = {
+            "message_type": "silence",
+            "output_events": [boundary_event],
+        }
+        coalesce_speech_end = (
+            signal.kind == "speech_ended"
+            and self.router.should_coalesce_speech_end_with_response(
+                self.virtual_agent_id
+            )
+        )
+
+        if not coalesce_speech_end:
+            response = self._convert_connector_response_to_grpc(
+                boundary_connector_response
+            )
+            if response is not None:
+                yield response
+
+        boundary_message_data = {
+            "conversation_id": self.conversation_id,
+            "virtual_agent_id": self.virtual_agent_id,
+            "input_type": "speech_boundary",
+            "speech_boundary": {"kind": signal.kind},
+        }
+        if speech_turn_committed:
+            boundary_message_data["speech_turn_committed"] = True
+
+        boundary_response = self.router.route_request(
+            self.virtual_agent_id,
+            "handle_speech_boundary",
+            self.conversation_id,
+            boundary_message_data,
+        )
+        if not coalesce_speech_end:
+            yield from self._iter_grpc_connector_responses(
+                boundary_response, include_single_response=False
+            )
+            return
+
+        is_iterator = (
+            hasattr(boundary_response, "__iter__")
+            and not isinstance(boundary_response, (dict, str, bytes))
+        )
+        if is_iterator:
+            boundary_responses = list(boundary_response)
+        elif boundary_response is None:
+            boundary_responses = []
+        else:
+            boundary_responses = [boundary_response]
+
+        has_terminal_response = any(
+            isinstance(response, dict)
+            and response.get("message_type") in {"transfer", "session_end"}
+            for response in boundary_responses
+        )
+        response_kind = "terminal" if has_terminal_response else "normal"
+        self.logger.info(
+            "Emitting END_OF_INPUT before %d %s connector response(s) for "
+            "conversation %s",
+            len(boundary_responses),
+            response_kind,
+            self.conversation_id,
+        )
+        response = self._convert_connector_response_to_grpc(
+            boundary_connector_response
+        )
+        if response is not None:
+            yield response
+        yield from self._iter_grpc_connector_responses(
+            boundary_responses,
+            delay_terminal_after_audio=has_terminal_response,
+        )
 
     def _iter_grpc_connector_responses(
         self,
@@ -1008,6 +1132,12 @@ class ConversationProcessor:
 
     def cleanup(self, termination_reason: str = "gateway_cleanup"):
         """Clean up conversation resources with a lifecycle reason."""
+        with self._speech_end_lock:
+            timer = self._pending_speech_end_timer
+            self._pending_speech_end_timer = None
+            self._async_task_count = 0
+        if timer is not None:
+            timer.cancel()
         try:
             # End the conversation with the connector
             message_data = {
@@ -1231,138 +1361,205 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
         conversation_id = None
         agent_id = None
         processor = None
-        stream_end_reason = "client_half_close"
         stream_cancel_event = threading.Event()
+        input_done = threading.Event()
+        response_queue: queue.Queue[VoiceVAResponse] = queue.Queue(maxsize=100)
+        state = {"stream_end_reason": "client_half_close"}
+
+        def wake_stream() -> None:
+            stream_cancel_event.set()
+
         if context:
-            context.add_callback(stream_cancel_event.set)
+            context.add_callback(wake_stream)
 
-        try:
-            for request in request_iterator:
-                # Extract conversation and agent information from the first request
-                if conversation_id is None:
-                    conversation_id = request.conversation_id
-                    agent_id = request.virtual_agent_id
+        def enqueue_response(response: VoiceVAResponse) -> bool:
+            while not stream_cancel_event.is_set():
+                try:
+                    response_queue.put(response, timeout=0.25)
+                    return True
+                except queue.Full:
+                    continue
+            return False
 
-                    # Use default agent if none specified
-                    if not agent_id:
-                        available_agents = self.router.get_all_available_agents()
-                        if available_agents:
-                            agent_id = available_agents[
-                                0
-                            ]  # Use first available agent as default
-                            self.logger.debug(
-                                f"No agent_id specified, using default: {agent_id}"
-                            )
-                        else:
-                            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-                            context.set_details("No virtual agents available")
+        def consume_requests() -> None:
+            nonlocal conversation_id, agent_id, processor
+            try:
+                for request in request_iterator:
+                    if stream_cancel_event.is_set():
+                        break
+
+                    # Extract conversation and agent information from the first request
+                    if conversation_id is None:
+                        conversation_id = request.conversation_id
+                        agent_id = request.virtual_agent_id
+
+                        # Use default agent if none specified
+                        if not agent_id:
+                            available_agents = self.router.get_all_available_agents()
+                            if available_agents:
+                                agent_id = available_agents[0]
+                                self.logger.debug(
+                                    "No agent_id specified, using default: %s",
+                                    agent_id,
+                                )
+                            else:
+                                context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+                                context.set_details("No virtual agents available")
+                                return
+
+                        try:
+                            self.router.get_connector_for_agent(agent_id)
+                        except ValueError:
+                            self.logger.error("Agent not found: %s", agent_id)
+                            context.set_code(grpc.StatusCode.NOT_FOUND)
+                            context.set_details(f"Agent not found: {agent_id}")
                             return
 
-                    # Verify agent exists
-                    try:
-                        self.router.get_connector_for_agent(agent_id)
-                    except ValueError:
-                        self.logger.error(f"Agent not found: {agent_id}")
-                        context.set_code(grpc.StatusCode.NOT_FOUND)
-                        context.set_details(f"Agent not found: {agent_id}")
-                        return
-
-                    # Create or get conversation processor
-                    if conversation_id not in self.conversations:
-                        processor = ConversationProcessor(
-                            conversation_id,
-                            agent_id,
-                            self.router,
-                            self.vad_config,
-                            self.max_terminal_playback_seconds,
-                        )
-                        self.conversations[conversation_id] = processor
-                        self.add_connection_event("start", conversation_id, agent_id)
-                        self.logger.debug(
-                            f"Created new conversation processor for {conversation_id}"
-                        )
-                    else:
-                        processor = self.conversations[conversation_id]
-                        if processor.virtual_agent_id != agent_id:
-                            self.logger.error(
-                                "Rejected conversation %s reconnection with agent %s; "
-                                "existing agent is %s",
+                        if conversation_id not in self.conversations:
+                            processor = ConversationProcessor(
                                 conversation_id,
                                 agent_id,
-                                processor.virtual_agent_id,
+                                self.router,
+                                self.vad_config,
+                                self.max_terminal_playback_seconds,
                             )
-                            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-                            context.set_details(
-                                "virtual_agent_id does not match the existing "
-                                "conversation"
+                            self.conversations[conversation_id] = processor
+                            self.add_connection_event(
+                                "start", conversation_id, agent_id
                             )
-                            return
-                        agent_id = processor.virtual_agent_id
+                            self.logger.debug(
+                                "Created new conversation processor for %s",
+                                conversation_id,
+                            )
+                        else:
+                            processor = self.conversations[conversation_id]
+                            if processor.virtual_agent_id != agent_id:
+                                self.logger.error(
+                                    "Rejected conversation %s reconnection with "
+                                    "agent %s; existing agent is %s",
+                                    conversation_id,
+                                    agent_id,
+                                    processor.virtual_agent_id,
+                                )
+                                context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+                                context.set_details(
+                                    "virtual_agent_id does not match the existing "
+                                    "conversation"
+                                )
+                                return
+                            agent_id = processor.virtual_agent_id
+                            self.logger.debug(
+                                "Using existing conversation processor for %s",
+                                conversation_id,
+                            )
+
+                        processor.set_stream_cancel_event(stream_cancel_event)
+                        processor.set_async_response_sink(enqueue_response)
+
+                    if request.HasField("audio_input"):
                         self.logger.debug(
-                            f"Using existing conversation processor for {conversation_id}"
+                            "Processing audio input for conversation %s",
+                            conversation_id,
+                        )
+                    elif request.HasField("dtmf_input"):
+                        self.logger.debug(
+                            "Processing DTMF input for conversation %s",
+                            conversation_id,
+                        )
+                    elif request.HasField("event_input"):
+                        event_type_name = (
+                            ConversationProcessor.EVENT_TYPE_NAMES.get(
+                                request.event_input.event_type,
+                                f"UNKNOWN({request.event_input.event_type})",
+                            )
+                        )
+                        self.logger.debug(
+                            "Processing event input for conversation %s: %s",
+                            conversation_id,
+                            event_type_name,
+                        )
+                    else:
+                        self.logger.warning(
+                            "Unknown input type for conversation %s",
+                            conversation_id,
                         )
 
-                    processor.set_stream_cancel_event(stream_cancel_event)
+                    for response in processor.process_request(request):
+                        if not enqueue_response(response):
+                            return
 
-                # Log the input type being processed
-                if request.HasField("audio_input"):
-                    self.logger.debug(
-                        f"Processing audio input for conversation {conversation_id}"
+                    self.add_connection_event(
+                        "message", conversation_id, agent_id
                     )
-                elif request.HasField("dtmf_input"):
-                    self.logger.debug(
-                        f"Processing DTMF input for conversation {conversation_id}"
-                    )
-                elif request.HasField("event_input"):
-                    event_type_name = ConversationProcessor.EVENT_TYPE_NAMES.get(
-                        request.event_input.event_type,
-                        f"UNKNOWN({request.event_input.event_type})",
-                    )
-                    self.logger.debug(
-                        f"Processing event input for conversation {conversation_id}: {event_type_name}"
-                    )
+                    if processor.can_be_deleted:
+                        state["stream_end_reason"] = "server_terminal"
+                        return
+
+            except grpc.RpcError as error:
+                if error.code() == grpc.StatusCode.CANCELLED:
+                    state["stream_end_reason"] = "client_cancelled"
                 else:
-                    self.logger.warning(
-                        f"Unknown input type for conversation {conversation_id}"
+                    state["stream_end_reason"] = "stream_error"
+                    self.logger.error(
+                        "Error in ProcessCallerInput stream: %s", error
                     )
-
-                # Process the request through the conversation processor
-                self.logger.debug(
-                    f"Processing request for conversation {conversation_id}"
+                    context.set_code(grpc.StatusCode.INTERNAL)
+                    context.set_details(f"Stream error: {str(error)}")
+            except Exception as error:
+                state["stream_end_reason"] = "stream_error"
+                self.logger.error(
+                    "Error in ProcessCallerInput stream: %s", error
                 )
-                self.logger.debug(f"Request: {request}")
+                context.set_code(grpc.StatusCode.INTERNAL)
+                context.set_details(f"Stream error: {str(error)}")
+            finally:
+                input_done.set()
 
-                yield from processor.process_request(request)
+        input_thread = threading.Thread(
+            target=consume_requests,
+            name="wxcc-ingress",
+            daemon=True,
+        )
+        input_thread.start()
 
-                # Track message event
-                self.add_connection_event("message", conversation_id, agent_id)
+        try:
+            while True:
+                try:
+                    response = response_queue.get(timeout=0.25)
+                except queue.Empty:
+                    if stream_cancel_event.is_set():
+                        break
+                    if (
+                        input_done.is_set()
+                        and response_queue.empty()
+                        and (processor is None or not processor.has_async_work())
+                    ):
+                        break
+                    continue
 
-                if processor.can_be_deleted:
-                    stream_end_reason = "server_terminal"
+                yield response
+                terminal_event = any(
+                    event.event_type
+                    in {
+                        OutputEvent.EventType.SESSION_END,
+                        OutputEvent.EventType.TRANSFER_TO_AGENT,
+                    }
+                    for event in response.output_events
+                )
+                if terminal_event:
+                    state["stream_end_reason"] = "server_terminal"
                     self.logger.info(
                         "Completing WxCC response stream after terminal response "
                         "for conversation %s",
                         conversation_id,
                     )
+                    stream_cancel_event.set()
                     break
-
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.CANCELLED:
-                stream_end_reason = "client_cancelled"
-            else:
-                stream_end_reason = "stream_error"
-                self.logger.error(f"Error in ProcessCallerInput stream: {e}")
-                context.set_code(grpc.StatusCode.INTERNAL)
-                context.set_details(f"Stream error: {str(e)}")
-        except Exception as e:
-            stream_end_reason = "stream_error"
-            self.logger.error(f"Error in ProcessCallerInput stream: {e}")
-            context.set_code(grpc.StatusCode.INTERNAL)
-            context.set_details(f"Stream error: {str(e)}")
         finally:
             stream_cancel_event.set()
+            input_thread.join(timeout=2.0)
             if context and not context.is_active():
-                stream_end_reason = "client_cancelled"
+                state["stream_end_reason"] = "client_cancelled"
 
             # WxCC normally half-closes one request RPC and reconnects with the
             # same conversation ID for subsequent caller input. Preserve the
@@ -1374,13 +1571,15 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
                 agent_id = processor.virtual_agent_id
                 cleanup_on_stream_end = (
                     not processor.can_be_deleted
-                    and stream_end_reason != "client_half_close"
+                    and state["stream_end_reason"] != "client_half_close"
                     and self.router.should_cleanup_on_client_stream_end(agent_id)
                     is True
                 )
                 if processor.can_be_deleted or cleanup_on_stream_end:
                     termination_reason = (
-                        "completed" if processor.can_be_deleted else stream_end_reason
+                        "completed"
+                        if processor.can_be_deleted
+                        else state["stream_end_reason"]
                     )
                     self.logger.debug(
                         "Cleaning up conversation %s (reason=%s)",

--- a/tests/test_gecx_connector.py
+++ b/tests/test_gecx_connector.py
@@ -175,6 +175,75 @@ class TestRequestGenerator:
 
         assert audio_messages == [b"23456789ABCD", b"\xff" * 800]
 
+    def test_gateway_vad_compacts_pause_and_merges_resume_preroll(
+        self, connector
+    ):
+        connector.input_preroll_ms = 1
+        connector.input_pause_preroll_ms = 1
+        connector.endpointing_silence_ms = 100
+        session = GECXStreamingSession(
+            connector=connector,
+            conversation_id="conv-1",
+            session_path="projects/p/locations/us/apps/a/sessions/s1",
+            deployment_path=connector.deployment_path,
+            initial_message=None,
+        )
+
+        session.enqueue_audio(b"0123456789")
+        session.begin_input_turn()
+        session.enqueue_audio(b"abcdefgh")
+        assert session.pause_input_turn(silence_ms=1) is True
+        session.enqueue_audio(b"ABCDEFGHIJKL")
+        assert session.resume_input_turn() is True
+        session.end_audio_turn()
+        session.inbound_queue.put(_STREAM_STOP)
+
+        generator = session._request_generator()
+        next(generator)  # config
+        audio_messages = [
+            message.realtime_input.audio for message in generator
+        ]
+
+        assert audio_messages == [b"23456789EFGHIJKL", b"\xff" * 800]
+
+    def test_committed_pause_preserves_resumed_onset_for_next_turn(
+        self, connector
+    ):
+        connector.input_preroll_ms = 1
+        connector.input_pause_preroll_ms = 1
+        connector.endpointing_silence_ms = 1
+        session = GECXStreamingSession(
+            connector=connector,
+            conversation_id="conv-1",
+            session_path="projects/p/locations/us/apps/a/sessions/s1",
+            deployment_path=connector.deployment_path,
+            initial_message=None,
+        )
+
+        session.enqueue_audio(b"0123456789")
+        session.begin_input_turn()
+        session.enqueue_audio(b"abcdefgh")
+        assert session.pause_input_turn(silence_ms=1) is True
+        session.enqueue_audio(b"ABCDEFGHIJKL")
+        assert session.end_audio_turn() is True
+        session.begin_input_turn()
+        session.enqueue_audio(b"mnopqrst")
+        assert session.end_audio_turn() is True
+        session.inbound_queue.put(_STREAM_STOP)
+
+        generator = session._request_generator()
+        next(generator)  # config
+        audio_messages = [
+            message.realtime_input.audio for message in generator
+        ]
+
+        assert audio_messages == [
+            b"23456789",
+            b"\xff" * 8,
+            b"EFGHIJKLmnopqrst",
+            b"\xff" * 8,
+        ]
+
 
 class TestServerMessageMapping:
     def test_session_output_maps_to_connector_responses(self, connector):
@@ -713,6 +782,26 @@ class TestSpeechBoundaries:
         stream_session.end_audio_turn.assert_called_once_with()
         stream_session.wait_for_turn_responses.assert_called_once_with(timeout=30.0)
         stream_session.wait_for_terminal_responses.assert_not_called()
+
+    def test_precommitted_speech_end_only_waits_for_response(self, connector):
+        stream_session = MagicMock()
+        stream_session.is_terminal = False
+        stream_session.wait_for_turn_responses.return_value = (True, [])
+
+        with patch.object(connector, "streaming_sessions", {"conv-1": stream_session}):
+            responses = list(
+                connector.handle_speech_boundary(
+                    "conv-1",
+                    {
+                        "speech_boundary": {"kind": "speech_ended"},
+                        "speech_turn_committed": True,
+                    },
+                )
+            )
+
+        assert responses == []
+        stream_session.end_audio_turn.assert_not_called()
+        stream_session.wait_for_turn_responses.assert_called_once_with(timeout=30.0)
 
     def test_speech_ended_yields_delayed_terminal_after_agent_audio(
         self, connector

--- a/tests/test_gecx_connector.py
+++ b/tests/test_gecx_connector.py
@@ -76,6 +76,14 @@ class TestGECXConnectorInit:
         assert connector.deployment_path.endswith("/deployments/d")
         assert connector.application_id == "a"
 
+    def test_default_endpointing_silence_has_margin_above_one_second(
+        self, gecx_config
+    ):
+        with patch("src.connectors.gecx_connector.ces_v1.SessionServiceClient"):
+            connector = GECXConnector(gecx_config)
+
+        assert connector.endpointing_silence_ms == 2000
+
 
 class TestRequestGenerator:
     def test_first_message_is_session_config(self, connector):
@@ -144,7 +152,7 @@ class TestRequestGenerator:
         next(generator)  # config
         endpointing_messages = list(generator)
 
-        assert len(endpointing_messages) == 10
+        assert len(endpointing_messages) == 20
         assert all(
             message.realtime_input.audio == b"\xff" * 800
             for message in endpointing_messages
@@ -674,7 +682,7 @@ class TestAudioFormat:
 
         chunks = connector.endpointing_silence_chunks()
 
-        assert len(chunks) == 10
+        assert len(chunks) == connector.endpointing_silence_ms // 100
         assert all(
             chunk == expected_byte * expected_chunk_size for chunk in chunks
         )

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -384,6 +384,7 @@ class TestConversationProcessor:
             assert resumed == []
             assert final_end == []
             assert len(FakeTimer.instances) == 2
+            assert [timer.interval for timer in FakeTimer.instances] == [1.0, 1.0]
             assert FakeTimer.instances[0].cancelled is True
 
             FakeTimer.instances[1].callback()
@@ -399,6 +400,33 @@ class TestConversationProcessor:
         assert operations.count("resume_speech_turn") == 1
         assert operations.count("commit_speech_turn") == 1
         assert operations.count("handle_speech_boundary") == 2
+
+    @pytest.mark.parametrize(
+        ("configured_grace_ms", "expected_grace_ms"),
+        [
+            (None, 1000),
+            (-1, 0),
+            (2500, 2000),
+        ],
+    )
+    def test_gateway_bounds_speech_end_grace(
+        self,
+        mock_router,
+        configured_grace_ms,
+        expected_grace_ms,
+    ):
+        vad_config = {}
+        if configured_grace_ms is not None:
+            vad_config["speech_end_grace_ms"] = configured_grace_ms
+
+        processor = ConversationProcessor(
+            conversation_id="test_conv_123",
+            virtual_agent_id="test_agent_456",
+            router=mock_router,
+            vad_config=vad_config,
+        )
+
+        assert processor.speech_end_grace_ms == expected_grace_ms
 
     def test_gateway_suppresses_overlapping_boundaries_while_response_pending(
         self, processor, mock_router, mock_audio_input

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -5,6 +5,8 @@ This module tests the gateway server's ability to handle both single responses
 and generator responses from connectors, as well as proper audio input processing.
 """
 
+import threading
+
 import grpc
 import pytest
 from unittest.mock import MagicMock, patch, Mock
@@ -301,6 +303,102 @@ class TestConversationProcessor:
         assert responses[2].prompts == []
         assert [event.event_type for event in responses[2].output_events] == [2]
         cancel_event.wait.assert_called_once_with(1.0)
+
+    def test_gateway_merges_speech_resumed_during_end_grace(
+        self, processor, mock_router, mock_audio_input
+    ):
+        class FakeTimer:
+            instances = []
+
+            def __init__(self, interval, callback):
+                self.interval = interval
+                self.callback = callback
+                self.cancelled = False
+                self.daemon = False
+                self.__class__.instances.append(self)
+
+            def start(self):
+                return None
+
+            def cancel(self):
+                self.cancelled = True
+
+        signals = iter(
+            [
+                [SpeechBoundarySignal("speech_started", "test_conv_123", 8000)],
+                [SpeechBoundarySignal("speech_ended", "test_conv_123", 8000)],
+                [SpeechBoundarySignal("speech_started", "test_conv_123", 8000)],
+                [SpeechBoundarySignal("speech_ended", "test_conv_123", 8000)],
+            ]
+        )
+        processor.speech_boundary_observer = MagicMock(
+            end_silence_ms=1000
+        )
+        processor.speech_boundary_observer.observe.side_effect = (
+            lambda _frame: next(signals)
+        )
+        mock_router.should_observe_speech_boundaries.return_value = True
+        mock_router.should_merge_speech_pauses.return_value = True
+        mock_router.should_coalesce_speech_end_with_response.return_value = True
+        audio_response = {
+            "message_type": "audio",
+            "text": "Which dates would you like?",
+            "audio_content": b"RIFFaudio",
+            "output_events": [],
+        }
+
+        def route_request(_agent_id, operation, _conversation_id, *args):
+            if operation in {
+                "send_message",
+                "pause_speech_turn",
+                "resume_speech_turn",
+                "commit_speech_turn",
+            }:
+                return None
+            if operation == "handle_speech_boundary":
+                boundary_kind = args[0]["speech_boundary"]["kind"]
+                return (
+                    iter([audio_response])
+                    if boundary_kind == "speech_ended"
+                    else None
+                )
+            raise AssertionError(f"unexpected operation: {operation}")
+
+        mock_router.route_request.side_effect = route_request
+        async_responses = []
+        processor.set_async_response_sink(
+            lambda response: not async_responses.append(response)
+        )
+
+        with patch(
+            "src.core.wxcc_gateway_server.threading.Timer", FakeTimer
+        ):
+            first = list(processor._process_audio_input(mock_audio_input))
+            held_end = list(processor._process_audio_input(mock_audio_input))
+            resumed = list(processor._process_audio_input(mock_audio_input))
+            final_end = list(processor._process_audio_input(mock_audio_input))
+
+            assert len(first) == 1
+            assert first[0].output_events[0].event_type == 4
+            assert held_end == []
+            assert resumed == []
+            assert final_end == []
+            assert len(FakeTimer.instances) == 2
+            assert FakeTimer.instances[0].cancelled is True
+
+            FakeTimer.instances[1].callback()
+
+        assert len(async_responses) == 2
+        assert async_responses[0].output_events[0].event_type == 5
+        assert async_responses[1].prompts[0].text == "Which dates would you like?"
+        assert processor.has_async_work() is False
+        operations = [
+            call.args[1] for call in mock_router.route_request.call_args_list
+        ]
+        assert operations.count("pause_speech_turn") == 2
+        assert operations.count("resume_speech_turn") == 1
+        assert operations.count("commit_speech_turn") == 1
+        assert operations.count("handle_speech_boundary") == 2
 
     def test_gateway_suppresses_delayed_terminal_after_stream_cancellation(
         self, processor
@@ -1258,6 +1356,32 @@ class TestClientStreamEndCleanup:
         assert len(responses) == 1
         assert consumed_second_request is True
         assert "stream-end-conv" in server.conversations
+
+    def test_ingress_continues_while_caller_has_not_requested_next_response(
+        self
+    ):
+        router = MagicMock(spec=VirtualAgentRouter)
+        router.route_request.side_effect = [self._session_start_response(), None]
+        router.should_cleanup_on_client_stream_end.return_value = True
+        context = MagicMock()
+        context.is_active.return_value = True
+        server = WxCCGatewayServer(router)
+        allow_second_request = threading.Event()
+        consumed_second_request = threading.Event()
+
+        def requests():
+            yield self._session_start_request()
+            assert allow_second_request.wait(1.0)
+            consumed_second_request.set()
+            yield self._custom_event_request()
+
+        responses = server.ProcessCallerInput(requests(), context)
+        first_response = next(responses)
+        allow_second_request.set()
+
+        assert first_response.prompts[0].text == "Connected"
+        assert consumed_second_request.wait(1.0)
+        assert list(responses) == []
 
     def test_opted_in_connector_survives_half_close_and_reconnection(self):
         router = MagicMock(spec=VirtualAgentRouter)

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -400,6 +400,109 @@ class TestConversationProcessor:
         assert operations.count("commit_speech_turn") == 1
         assert operations.count("handle_speech_boundary") == 2
 
+    def test_gateway_suppresses_overlapping_boundaries_while_response_pending(
+        self, processor, mock_router, mock_audio_input
+    ):
+        class FakeTimer:
+            instances = []
+
+            def __init__(self, interval, callback):
+                self.interval = interval
+                self.callback = callback
+                self.daemon = False
+                self.__class__.instances.append(self)
+
+            def start(self):
+                return None
+
+            def cancel(self):
+                return None
+
+        signals = iter(
+            [
+                [SpeechBoundarySignal("speech_started", "test_conv_123", 8000)],
+                [SpeechBoundarySignal("speech_ended", "test_conv_123", 8000)],
+                [SpeechBoundarySignal("speech_started", "test_conv_123", 8000)],
+                [SpeechBoundarySignal("speech_ended", "test_conv_123", 8000)],
+            ]
+        )
+        processor.speech_boundary_observer = MagicMock(end_silence_ms=1000)
+        processor.speech_boundary_observer.observe.side_effect = (
+            lambda _frame: next(signals)
+        )
+        mock_router.should_observe_speech_boundaries.return_value = True
+        mock_router.should_merge_speech_pauses.return_value = True
+        mock_router.should_coalesce_speech_end_with_response.return_value = True
+        response_waiting = threading.Event()
+        release_response = threading.Event()
+        audio_response = {
+            "message_type": "audio",
+            "text": "Complete request received",
+            "audio_content": b"RIFFaudio",
+            "output_events": [],
+        }
+
+        def delayed_response():
+            response_waiting.set()
+            assert release_response.wait(1.0)
+            yield audio_response
+
+        def route_request(_agent_id, operation, _conversation_id, *args):
+            if operation in {
+                "send_message",
+                "pause_speech_turn",
+                "resume_speech_turn",
+                "commit_speech_turn",
+            }:
+                return None
+            if operation == "handle_speech_boundary":
+                boundary_kind = args[0]["speech_boundary"]["kind"]
+                return (
+                    delayed_response()
+                    if boundary_kind == "speech_ended"
+                    else None
+                )
+            raise AssertionError(f"unexpected operation: {operation}")
+
+        mock_router.route_request.side_effect = route_request
+        async_responses = []
+        processor.set_async_response_sink(
+            lambda response: not async_responses.append(response)
+        )
+
+        with patch(
+            "src.core.wxcc_gateway_server.threading.Timer", FakeTimer
+        ):
+            first = list(processor._process_audio_input(mock_audio_input))
+            assert list(processor._process_audio_input(mock_audio_input)) == []
+
+            first_waiter = threading.Thread(
+                target=FakeTimer.instances[0].callback
+            )
+            first_waiter.start()
+            assert response_waiting.wait(1.0)
+
+            resumed = list(processor._process_audio_input(mock_audio_input))
+            assert list(processor._process_audio_input(mock_audio_input)) == []
+            FakeTimer.instances[1].callback()
+            release_response.set()
+            first_waiter.join(timeout=1.0)
+
+        assert not first_waiter.is_alive()
+        assert len(first) == 1
+        assert first[0].output_events[0].event_type == 4
+        assert resumed == []
+        assert len(async_responses) == 2
+        assert async_responses[0].output_events[0].event_type == 5
+        assert async_responses[1].prompts[0].text == "Complete request received"
+        operations = [
+            call.args[1] for call in mock_router.route_request.call_args_list
+        ]
+        assert operations.count("pause_speech_turn") == 2
+        assert operations.count("commit_speech_turn") == 2
+        assert operations.count("handle_speech_boundary") == 3
+        assert processor.has_async_work() is False
+
     def test_gateway_suppresses_delayed_terminal_after_stream_cancellation(
         self, processor
     ):


### PR DESCRIPTION
## Summary

- preserve one GECX caller turn when speech resumes during a bounded natural-pause window
- defer and finalize `END_OF_INPUT` exactly once after the configured resume grace expires
- suppress duplicate speech boundaries when delayed callbacks and later audio race
- append a two-second codec-correct endpointing margin when submitting the completed caller turn to CES
- document the timing controls and apply bounded defaults to local and Cloud Run configuration

## Why

The gateway's VAD declares speech ended after one second of silence. The previous implementation immediately finalized the GECX input turn at that point. A caller who paused naturally and resumed could therefore have one sentence split into multiple CES turns, generate duplicate Webex speech boundaries, or receive no response.

The gateway now holds a pending speech end for a configurable resume grace. Audio that resumes inside the window cancels the pending end and remains part of the same GECX turn. If no speech resumes, the gateway finalizes the turn once.

The default timing is bounded:

- `end_silence_ms: 1000`
- `speech_end_grace_ms: 1000`
- maximum accepted `speech_end_grace_ms: 2000`

With the defaults, callers receive a two-second total natural-pause window. `endpointing_silence_ms: 2000` is a separate codec-level margin sent to CES after the completed caller turn so short utterances endpoint reliably.

## Validation

- `378 passed` — complete gateway test suite
- `git diff --check` passed
- branch contains no `tools/byova_e2e` delta; the headless tester enhancement was merged separately in PR #29

Live headless validation used the dedicated `testcaller@adweeks-0xlz.wbx.ai` caller:

- injected `"I'd like to book"` and `"a room in San Jose"` with exactly 1.8 seconds of silence
- Webex/gateway logs showed one `START_OF_INPUT`, resumed speech merged into the active caller turn, and one final `END_OF_INPUT`
- CES conversation `f009d646ec3d4fb380f805fc28046291` recorded one user transcript: `"I'd like to book a room in San Jose"`
- the virtual-agent response was observed by the headless caller

## Tracking

[SE-1943](https://jira-eng-gpk2.cisco.com/jira/browse/SE-1943)
