### PR TITLE
feat(e2e): support ordered caller injections

### DIFF
--- a/tools/byova_e2e/README.md
+++ b/tools/byova_e2e/README.md
@@ -1,8 +1,9 @@
 # BYOVA E2E Test Caller
 
 This local tool uses a Python orchestrator and a browser-only Webex Calling SDK
-client to call the WxCC extension and inject one prepared caller utterance after
-the remote prompt becomes quiet.
+client to call the WxCC extension and inject one or more prepared caller
+utterances. The first action waits for the configured remote prompt; later
+actions follow their preceding expectations in the JSON test plan.
 
 ## One-time setup
 
@@ -178,11 +179,14 @@ media debugging is required.
 
 ## Define tests in JSON
 
-Each version 1 test contains one audio action followed by one expectation. A
+Each version 1 test contains alternating audio actions and expectations. A
 `speak` action accepts either `text` or `segments` plus `pauseMs`; a `play`
-action accepts a WAV `path` relative to the config file. Test plans follow
-Playwright conventions: top-level `use` defaults, named `tests`, ordered
-`steps`, and explicit `expect` assertions. Reference
+action accepts a WAV `path` relative to the config file. `response` waits for a
+complete remote prompt. `response-start` waits only until remote audio becomes
+active, allowing the next action to exercise caller speech during playback.
+`session-end` and `transfer` are terminal expectations and must be the final
+step. Test plans follow Playwright conventions: top-level `use` defaults, named
+`tests`, ordered `steps`, and explicit `expect` assertions. Reference
 `config/byova-e2e.schema.json` for editor validation and autocomplete.
 
 ```json
@@ -215,6 +219,26 @@ Playwright conventions: top-level `use` defaults, named `tests`, ordered
   ]
 }
 ```
+
+A two-turn test uses the same action/expectation rhythm:
+
+```json
+{
+  "id": "two-turn",
+  "title": "continues the conversation for a second caller turn",
+  "steps": [
+    {"action": "speak", "text": "I need a hotel."},
+    {"expect": {"outcome": "response"}},
+    {"action": "speak", "text": "A queen room, please."},
+    {"expect": {"outcome": "response"}}
+  ]
+}
+```
+
+To inject the second utterance while the first response is playing, replace the
+first `response` outcome with `response-start`. The final `response`
+expectation then proves that the second caller utterance reached the virtual
+agent and produced a later complete reply.
 
 Validate and list the plan without authenticating or placing a call:
 

--- a/tools/byova_e2e/config/byova-e2e.schema.json
+++ b/tools/byova_e2e/config/byova-e2e.schema.json
@@ -93,27 +93,24 @@
           "$ref": "#/definitions/use"
         },
         "steps": {
-          "items": [
-            {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/speakText"
-                },
-                {
-                  "$ref": "#/definitions/speakSegments"
-                },
-                {
-                  "$ref": "#/definitions/play"
-                }
-              ]
-            },
-            {
-              "$ref": "#/definitions/expectStep"
-            }
-          ],
-          "additionalItems": false,
-          "minItems": 2,
-          "maxItems": 2
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/speakText"
+              },
+              {
+                "$ref": "#/definitions/speakSegments"
+              },
+              {
+                "$ref": "#/definitions/play"
+              },
+              {
+                "$ref": "#/definitions/expectStep"
+              }
+            ]
+          },
+          "minItems": 2
         }
       }
     },
@@ -210,6 +207,7 @@
             "outcome": {
               "enum": [
                 "response",
+                "response-start",
                 "session-end",
                 "transfer"
               ]

--- a/tools/byova_e2e/src/byova_e2e/cli.py
+++ b/tools/byova_e2e/src/byova_e2e/cli.py
@@ -23,8 +23,16 @@ from .auth import (
     complete_login,
     load_local_environment,
 )
-from .models import ExpectedOutcome, RunConfig
+from .models import (
+    AudioAsset,
+    ExpectedOutcome,
+    RunAction,
+    RunConfig,
+    RunExpectation,
+)
 from .plan import (
+    ExpectStepDefinition,
+    InputStepDefinition,
     TestDefinition,
     TestPlanError,
     load_plan,
@@ -121,7 +129,11 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--response-timeout-seconds", type=float, default=None)
     run.add_argument(
         "--expect-outcome",
-        choices=[outcome.value for outcome in ExpectedOutcome],
+        choices=[
+            ExpectedOutcome.RESPONSE.value,
+            ExpectedOutcome.SESSION_END.value,
+            ExpectedOutcome.TRANSFER.value,
+        ],
         help=(
             "Assert a normal response, successful session-end disconnect, or "
             "configured transfer announcement sequence"
@@ -323,31 +335,86 @@ def _run(args: argparse.Namespace) -> None:
 
     token = access_token_for_run(OAuthTokenStore(TOKEN_PATH))
     with tempfile.TemporaryDirectory(prefix="byova-e2e-") as temp_dir:
-        audio_path = Path(temp_dir) / "caller.wav"
-        if text is not None:
-            prepared = render_text(text, voice, audio_path)
-            audio_profile = {"kind": "text"}
-        elif text_segments is not None:
-            prepared = render_text_sequence(
-                text_segments,
-                segment_pause_ms,
-                voice,
-                audio_path,
-            )
-            audio_profile = {
-                "kind": "segmented_text",
-                "segment_count": len(text_segments),
-                "segment_pause_ms": segment_pause_ms,
-            }
+        temp_path = Path(temp_dir)
+        if selected_test is not None:
+            audio_assets: list[AudioAsset] = []
+            audio_profiles: list[dict[str, object]] = []
+            run_steps: list[RunAction | RunExpectation] = []
+            action_index = 0
+            for step_index, step in enumerate(selected_test.steps):
+                if isinstance(step, InputStepDefinition):
+                    prepared_step, profile = _prepare_input_step(
+                        step,
+                        voice,
+                        temp_path / f"caller-{action_index}.wav",
+                    )
+                    audio_assets.append(
+                        AudioAsset(
+                            path=prepared_step.path,
+                            sha256=prepared_step.sha256,
+                            duration_seconds=prepared_step.duration_seconds,
+                        )
+                    )
+                    audio_profiles.append(profile)
+                    run_steps.append(
+                        RunAction(audio_index=action_index, name=step.name)
+                    )
+                    action_index += 1
+                    continue
+                if not isinstance(step, ExpectStepDefinition):
+                    raise CLIError(f"Unsupported test step at index {step_index}")
+                is_final_step = step_index == len(selected_test.steps) - 1
+                run_steps.append(
+                    RunExpectation(
+                        outcome=(
+                            expected_outcome
+                            if is_final_step and expected_outcome is not None
+                            else step.outcome
+                        ),
+                        response_prompts=(
+                            expected_response_prompts
+                            if is_final_step
+                            else step.response_prompts
+                        ),
+                        connected_observation_seconds=(
+                            connected_observation_seconds
+                            if is_final_step
+                            else step.connected_observation_seconds
+                        ),
+                        name=step.name,
+                    )
+                )
         else:
-            prepared = prepare_wav(wav, audio_path)
-            audio_profile = {"kind": "wav"}
+            direct_step = InputStepDefinition(
+                text=text,
+                text_segments=tuple(text_segments or ()),
+                wav=wav,
+                segment_pause_ms=(
+                    segment_pause_ms if text_segments is not None else None
+                ),
+            )
+            prepared_step, profile = _prepare_input_step(
+                direct_step,
+                voice,
+                temp_path / "caller-0.wav",
+            )
+            audio_assets = [
+                AudioAsset(
+                    path=prepared_step.path,
+                    sha256=prepared_step.sha256,
+                    duration_seconds=prepared_step.duration_seconds,
+                )
+            ]
+            audio_profiles = [profile]
+            run_steps = []
+
+        primary_audio = audio_assets[0]
         config = RunConfig(
             destination=args.destination,
             access_token=token,
-            audio_path=prepared.path,
-            audio_sha256=prepared.sha256,
-            audio_duration_seconds=prepared.duration_seconds,
+            audio_path=primary_audio.path,
+            audio_sha256=primary_audio.sha256,
+            audio_duration_seconds=primary_audio.duration_seconds,
             remote_silence_seconds=remote_silence_ms / 1000,
             initial_silence_fallback_seconds=initial_silence_fallback_seconds,
             prompt_timeout_seconds=prompt_timeout_seconds,
@@ -360,6 +427,8 @@ def _run(args: argparse.Namespace) -> None:
             expected_response_prompts=expected_response_prompts,
             connected_observation_seconds=connected_observation_seconds,
             headless=headless,
+            audio_assets=tuple(audio_assets),
+            steps=tuple(run_steps),
         )
         result = BrowserRunner(TOOL_ROOT, config).run()
 
@@ -370,7 +439,17 @@ def _run(args: argparse.Namespace) -> None:
             "status": "completed",
             "audio_sha256": config.audio_sha256,
             "audio_duration_seconds": config.audio_duration_seconds,
-            "audio_profile": audio_profile,
+            "audio_profile": audio_profiles[0],
+            "audio_profiles": [
+                {
+                    **profile,
+                    "sha256": asset.sha256,
+                    "duration_seconds": asset.duration_seconds,
+                }
+                for profile, asset in zip(
+                    audio_profiles, config.prepared_audio(), strict=True
+                )
+            ],
             "prompt_profile": {
                 "remote_prompt_occurrence": config.remote_prompt_occurrence,
                 "remote_silence_ms": round(config.remote_silence_seconds * 1000),
@@ -388,6 +467,35 @@ def _run(args: argparse.Namespace) -> None:
         },
     )
     print(f"BYOVA E2E caller completed. Artifact: {artifact}")
+
+
+def _prepare_input_step(
+    step: InputStepDefinition,
+    voice: str,
+    output_path: Path,
+):
+    """Render or normalize one configured caller-audio action."""
+    if step.text is not None:
+        return render_text(step.text, voice, output_path), {"kind": "text"}
+    if step.text_segments:
+        if step.segment_pause_ms is None:
+            raise CLIError("Segmented speech is missing pauseMs")
+        return (
+            render_text_sequence(
+                list(step.text_segments),
+                step.segment_pause_ms,
+                voice,
+                output_path,
+            ),
+            {
+                "kind": "segmented_text",
+                "segment_count": len(step.text_segments),
+                "segment_pause_ms": step.segment_pause_ms,
+            },
+        )
+    if step.wav is None:
+        raise CLIError("Audio action has no text, segments, or WAV path")
+    return prepare_wav(step.wav, output_path), {"kind": "wav"}
 
 
 def _configured(

--- a/tools/byova_e2e/src/byova_e2e/models.py
+++ b/tools/byova_e2e/src/byova_e2e/models.py
@@ -12,8 +12,36 @@ class ExpectedOutcome(str, Enum):
     """Caller-observable outcome required for a successful E2E run."""
 
     RESPONSE = "response"
+    RESPONSE_START = "response-start"
     SESSION_END = "session-end"
     TRANSFER = "transfer"
+
+
+@dataclass(frozen=True)
+class AudioAsset:
+    """One prepared caller-audio file available to the browser."""
+
+    path: Path
+    sha256: str
+    duration_seconds: float
+
+
+@dataclass(frozen=True)
+class RunAction:
+    """Inject one prepared caller-audio asset."""
+
+    audio_index: int
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class RunExpectation:
+    """Wait for one caller-observable outcome."""
+
+    outcome: ExpectedOutcome
+    response_prompts: int = 1
+    connected_observation_seconds: float = 0.0
+    name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -37,6 +65,20 @@ class RunConfig:
     expected_response_prompts: int = 1
     connected_observation_seconds: float = 0.0
     headless: bool = False
+    audio_assets: tuple[AudioAsset, ...] = ()
+    steps: tuple[RunAction | RunExpectation, ...] = ()
+
+    def prepared_audio(self) -> tuple[AudioAsset, ...]:
+        """Return multi-step assets or the legacy single caller fixture."""
+        if self.audio_assets:
+            return self.audio_assets
+        return (
+            AudioAsset(
+                path=self.audio_path,
+                sha256=self.audio_sha256,
+                duration_seconds=self.audio_duration_seconds,
+            ),
+        )
 
 
 @dataclass(frozen=True)

--- a/tools/byova_e2e/src/byova_e2e/plan.py
+++ b/tools/byova_e2e/src/byova_e2e/plan.py
@@ -30,6 +30,27 @@ class TestPlanError(ValueError):
 
 
 @dataclass(frozen=True)
+class InputStepDefinition:
+    """One prepared caller-audio action in an ordered test."""
+
+    name: str | None = None
+    text: str | None = None
+    text_segments: tuple[str, ...] = ()
+    wav: Path | None = None
+    segment_pause_ms: int | None = None
+
+
+@dataclass(frozen=True)
+class ExpectStepDefinition:
+    """One caller-observable expectation in an ordered test."""
+
+    outcome: ExpectedOutcome
+    name: str | None = None
+    response_prompts: int = 1
+    connected_observation_seconds: float = 0.0
+
+
+@dataclass(frozen=True)
 class TestDefinition:
     """One selected test after top-level and test-level settings are merged."""
 
@@ -38,6 +59,7 @@ class TestDefinition:
     description: str
     source_file: Path
     config_sha256: str
+    steps: tuple[InputStepDefinition | ExpectStepDefinition, ...] = ()
     text: str | None = None
     text_segments: tuple[str, ...] = ()
     wav: Path | None = None
@@ -143,13 +165,44 @@ def _parse_test(
     test_use = _parse_use(value.get("use", {}), f"{location}.use")
     merged_use = {**shared_use, **test_use}
 
-    steps = value.get("steps")
-    if not isinstance(steps, list) or len(steps) != 2:
+    raw_steps = value.get("steps")
+    if not isinstance(raw_steps, list) or len(raw_steps) < 2:
         raise TestPlanError(
-            f"{location}.steps must contain one audio action followed by one expect step"
+            f"{location}.steps must contain at least one audio action and expectation"
         )
-    input_values = _parse_input_step(steps[0], f"{location}.steps[0]", source_file)
-    expectation_values = _parse_expect_step(steps[1], f"{location}.steps[1]")
+    if len(raw_steps) % 2:
+        raise TestPlanError(
+            f"{location}.steps must alternate audio actions and expectations"
+        )
+
+    parsed_steps: list[InputStepDefinition | ExpectStepDefinition] = []
+    for step_index, raw_step in enumerate(raw_steps):
+        step_location = f"{location}.steps[{step_index}]"
+        if step_index % 2 == 0:
+            parsed_steps.append(
+                _parse_input_step(raw_step, step_location, source_file)
+            )
+        else:
+            parsed_steps.append(_parse_expect_step(raw_step, step_location))
+
+    for step_index, step in enumerate(parsed_steps[:-1]):
+        if isinstance(step, ExpectStepDefinition) and step.outcome in {
+            ExpectedOutcome.SESSION_END,
+            ExpectedOutcome.TRANSFER,
+        }:
+            raise TestPlanError(
+                f"{location}.steps[{step_index}] terminal outcome must be final"
+            )
+    final_expectation = parsed_steps[-1]
+    if not isinstance(final_expectation, ExpectStepDefinition):
+        raise AssertionError("validated test must end with an expectation")
+    if final_expectation.outcome == ExpectedOutcome.RESPONSE_START:
+        raise TestPlanError(
+            f"{location}.steps must not end with a response-start expectation"
+        )
+    first_input = parsed_steps[0]
+    if not isinstance(first_input, InputStepDefinition):
+        raise AssertionError("validated test must start with an input action")
 
     return TestDefinition(
         test_id=test_id,
@@ -157,7 +210,11 @@ def _parse_test(
         description=description or title,
         source_file=source_file,
         config_sha256=config_sha256,
-        **input_values,
+        steps=tuple(parsed_steps),
+        text=first_input.text,
+        text_segments=first_input.text_segments,
+        wav=first_input.wav,
+        segment_pause_ms=first_input.segment_pause_ms,
         voice=merged_use.get("voice"),
         headless=merged_use.get("headless"),
         remote_silence_ms=merged_use.get("remoteSilenceMs"),
@@ -169,18 +226,24 @@ def _parse_test(
         call_timeout_seconds=merged_use.get("callTimeoutSeconds"),
         post_audio_grace_seconds=merged_use.get("postAudioGraceSeconds"),
         response_timeout_seconds=merged_use.get("responseTimeoutSeconds"),
-        **expectation_values,
+        expected_outcome=final_expectation.outcome,
+        expected_response_prompts=final_expectation.response_prompts,
+        connected_observation_seconds=(
+            final_expectation.connected_observation_seconds
+        ),
     )
 
 
-def _parse_input_step(raw: Any, location: str, source_file: Path) -> dict[str, Any]:
+def _parse_input_step(
+    raw: Any, location: str, source_file: Path
+) -> InputStepDefinition:
     step = _object(raw, location)
     _reject_unknown(
         step,
         {"name", "action", "text", "segments", "pauseMs", "path"},
         location,
     )
-    _optional_nonempty_string(step.get("name"), f"{location}.name")
+    name = _optional_nonempty_string(step.get("name"), f"{location}.name")
     action = _nonempty_string(step.get("action"), f"{location}.action")
     if action == "speak":
         has_text = "text" in step
@@ -197,23 +260,25 @@ def _parse_input_step(raw: Any, location: str, source_file: Path) -> dict[str, A
                 raise TestPlanError(
                     f"{location}.pauseMs is only valid with segmented speech"
                 )
-            return {
-                "text": _nonempty_string(step["text"], f"{location}.text"),
-            }
+            return InputStepDefinition(
+                name=name,
+                text=_nonempty_string(step["text"], f"{location}.text"),
+            )
         segments = step["segments"]
         if not isinstance(segments, list) or len(segments) < 2:
             raise TestPlanError(
                 f"{location}.segments must contain at least two strings"
             )
-        return {
-            "text_segments": tuple(
+        return InputStepDefinition(
+            name=name,
+            text_segments=tuple(
                 _nonempty_string(segment, f"{location}.segments[{index}]")
                 for index, segment in enumerate(segments)
             ),
-            "segment_pause_ms": _positive_integer(
+            segment_pause_ms=_positive_integer(
                 step.get("pauseMs"), f"{location}.pauseMs"
             ),
-        }
+        )
     if action == "play":
         if any(field in step for field in ("text", "segments", "pauseMs")):
             raise TestPlanError(
@@ -223,14 +288,14 @@ def _parse_input_step(raw: Any, location: str, source_file: Path) -> dict[str, A
         wav = Path(wav_value).expanduser()
         if not wav.is_absolute():
             wav = source_file.parent / wav
-        return {"wav": wav.resolve()}
+        return InputStepDefinition(name=name, wav=wav.resolve())
     raise TestPlanError(f"{location}.action must be 'speak' or 'play'")
 
 
-def _parse_expect_step(raw: Any, location: str) -> dict[str, Any]:
+def _parse_expect_step(raw: Any, location: str) -> ExpectStepDefinition:
     step = _object(raw, location)
     _reject_unknown(step, {"name", "expect"}, location)
-    _optional_nonempty_string(step.get("name"), f"{location}.name")
+    name = _optional_nonempty_string(step.get("name"), f"{location}.name")
     expect = _object(step.get("expect"), f"{location}.expect")
     _reject_unknown(
         expect,
@@ -264,11 +329,12 @@ def _parse_expect_step(raw: Any, location: str) -> dict[str, Any]:
             f"{location}.expect.connectedObservationSeconds is only valid "
             "for transfer outcomes"
         )
-    return {
-        "expected_outcome": expected_outcome,
-        "expected_response_prompts": expected_response_prompts,
-        "connected_observation_seconds": connected_observation_seconds,
-    }
+    return ExpectStepDefinition(
+        name=name,
+        outcome=expected_outcome,
+        response_prompts=expected_response_prompts,
+        connected_observation_seconds=connected_observation_seconds,
+    )
 
 
 def _parse_use(raw: Any, location: str) -> dict[str, Any]:

--- a/tools/byova_e2e/src/byova_e2e/runner.py
+++ b/tools/byova_e2e/src/byova_e2e/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import time
+from collections import deque
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -241,6 +242,8 @@ class BrowserRunner:
         observations: list[ResponseObservation] = []
         last_injection: RunEvent | None = None
         first_action = True
+        prior_response_active = False
+        events_during_injection: tuple[RunEvent, ...] = ()
 
         for step_index, step in enumerate(self.config.steps):
             if isinstance(step, RunAction):
@@ -262,14 +265,12 @@ class BrowserRunner:
                             "trigger": "scenario_step",
                         },
                     )
-                last_injection = self._wait_for(
-                    server,
-                    lambda event, expected_index=audio_index: (
-                        event.name == "injection_finished"
-                        and event.details.get("injectionIndex")
-                        == expected_index
-                    ),
-                    self._bounded_timeout(30, call_deadline),
+                last_injection, events_during_injection = (
+                    self._wait_for_injection_finished(
+                        server,
+                        audio_index,
+                        self._bounded_timeout(30, call_deadline),
+                    )
                 )
                 step_results.append(
                     {
@@ -289,8 +290,12 @@ class BrowserRunner:
 
             if step.outcome == ExpectedOutcome.RESPONSE_START:
                 response_start = self._wait_for_response_start(
-                    server, call_deadline
+                    server,
+                    call_deadline,
+                    prefetched_events=events_during_injection,
+                    ignore_current_prompt=prior_response_active,
                 )
+                prior_response_active = True
                 step_results.append(
                     {
                         "index": step_index,
@@ -314,7 +319,10 @@ class BrowserRunner:
                     step.outcome == ExpectedOutcome.SESSION_END
                 ),
                 expected_response_prompts=step.response_prompts,
+                prefetched_events=events_during_injection,
+                ignore_current_prompt=prior_response_active,
             )
+            prior_response_active = False
             observations.append(observation)
             step_results.append(
                 {
@@ -359,17 +367,36 @@ class BrowserRunner:
         )
 
     def _wait_for_response_start(
-        self, server: LocalRunServer, call_deadline: float
+        self,
+        server: LocalRunServer,
+        call_deadline: float,
+        *,
+        prefetched_events: tuple[RunEvent, ...] = (),
+        ignore_current_prompt: bool = False,
     ) -> RunEvent:
         deadline = min(
             time.monotonic() + self.config.response_timeout_seconds,
             call_deadline,
         )
+        pending = deque(prefetched_events)
+        waiting_for_prior_inactive = ignore_current_prompt
         while time.monotonic() < deadline:
-            event = self._next_event(
-                server, min(0.2, deadline - time.monotonic())
+            event = (
+                pending.popleft()
+                if pending
+                else self._next_event(
+                    server, min(0.2, deadline - time.monotonic())
+                )
             )
             if event is None:
+                continue
+            if waiting_for_prior_inactive:
+                if event.name == "remote_audio_inactive":
+                    waiting_for_prior_inactive = False
+                elif event.name == "disconnect":
+                    raise RunFailure(
+                        "Call disconnected before remote response audio started"
+                    )
                 continue
             if event.name == "remote_audio_active":
                 return event
@@ -378,6 +405,36 @@ class BrowserRunner:
                     "Call disconnected before remote response audio started"
                 )
         raise RunFailure("No remote response audio started after caller injection")
+
+    def _wait_for_injection_finished(
+        self,
+        server: LocalRunServer,
+        audio_index: int,
+        timeout: float,
+    ) -> tuple[RunEvent, tuple[RunEvent, ...]]:
+        """Wait for one caller asset while retaining concurrent remote events."""
+        deadline = time.monotonic() + timeout
+        concurrent_events: list[RunEvent] = []
+        while time.monotonic() < deadline:
+            event = self._next_event(
+                server, min(0.2, deadline - time.monotonic())
+            )
+            if event is None:
+                continue
+            if (
+                event.name == "injection_finished"
+                and event.details.get("injectionIndex") == audio_index
+            ):
+                return event, tuple(concurrent_events)
+            if event.name in {
+                "remote_audio_active",
+                "remote_audio_inactive",
+                "disconnect",
+            }:
+                concurrent_events.append(event)
+        raise RunFailure(
+            f"Timed out after {timeout:.1f}s waiting for caller audio {audio_index}"
+        )
 
     @staticmethod
     def _scenario_result(
@@ -519,6 +576,8 @@ class BrowserRunner:
         *,
         wait_for_disconnect: bool = False,
         expected_response_prompts: int | None = None,
+        prefetched_events: tuple[RunEvent, ...] = (),
+        ignore_current_prompt: bool = False,
     ) -> ResponseObservation:
         required_prompts = (
             self.config.expected_response_prompts
@@ -533,13 +592,28 @@ class BrowserRunner:
         remote_active = False
         quiet_since: float | None = None
         prompt_count = 0
+        pending = deque(prefetched_events)
+        waiting_for_prior_inactive = ignore_current_prompt
         while time.monotonic() < deadline:
-            event = self._next_event(
-                server,
-                min(0.2, deadline - time.monotonic()),
+            event = (
+                pending.popleft()
+                if pending
+                else self._next_event(
+                    server,
+                    min(0.2, deadline - time.monotonic()),
+                )
             )
             now = time.monotonic()
             if event is not None:
+                if waiting_for_prior_inactive:
+                    if event.name == "remote_audio_inactive":
+                        waiting_for_prior_inactive = False
+                    elif event.name == "disconnect":
+                        raise RunFailure(
+                            "Call disconnected before the required remote "
+                            "response outcome was observed"
+                        )
+                    continue
                 if event.name == "disconnect":
                     if wait_for_disconnect and first_active is not None:
                         if remote_active or quiet_since is not None:

--- a/tools/byova_e2e/src/byova_e2e/runner.py
+++ b/tools/byova_e2e/src/byova_e2e/runner.py
@@ -14,7 +14,13 @@ from urllib.parse import urlsplit
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import sync_playwright
 
-from .models import ExpectedOutcome, RunConfig, RunEvent
+from .models import (
+    ExpectedOutcome,
+    RunAction,
+    RunConfig,
+    RunEvent,
+    RunExpectation,
+)
 from .server import LocalRunServer
 from .state import PromptGate
 
@@ -89,18 +95,23 @@ class BrowserRunner:
                             self.config.prompt_timeout_seconds, deadline
                         ),
                     )
-                    self._wait_for_prompt_end(server, page, deadline)
-                    injection_finished = self._wait_for(
-                        server,
-                        lambda event: event.name == "injection_finished",
-                        self._bounded_timeout(30, deadline),
-                    )
-                    finish_result = self._finish_call(
-                        server,
-                        page,
-                        deadline,
-                        injection_finished,
-                    )
+                    if self.config.steps:
+                        finish_result = self._execute_steps(
+                            server, page, deadline
+                        )
+                    else:
+                        self._wait_for_prompt_end(server, page, deadline)
+                        injection_finished = self._wait_for(
+                            server,
+                            lambda event: event.name == "injection_finished",
+                            self._bounded_timeout(30, deadline),
+                        )
+                        finish_result = self._finish_call(
+                            server,
+                            page,
+                            deadline,
+                            injection_finished,
+                        )
                     final_reason = str(finish_result["completion_reason"])
                 finally:
                     # A crashed browser can make close() fail. Preserve the original
@@ -138,6 +149,7 @@ class BrowserRunner:
                 "observed_remote_prompt_count"
             ],
             "disconnect": finish_result["disconnect"],
+            "steps": finish_result.get("steps", []),
             "events": [
                 {
                     "name": event.name,
@@ -166,7 +178,11 @@ class BrowserRunner:
         return static_root
 
     def _wait_for_prompt_end(
-        self, server: LocalRunServer, page: Any, call_deadline: float
+        self,
+        server: LocalRunServer,
+        page: Any,
+        call_deadline: float,
+        audio_index: int = 0,
     ) -> None:
         gate = PromptGate(
             self.config.remote_silence_seconds,
@@ -188,7 +204,11 @@ class BrowserRunner:
                 elif event.name == "remote_audio_inactive":
                     gate.remote_audio_inactive(time.monotonic())
             if gate.ready_to_inject(time.monotonic()):
-                self._command(page, "injectAudio", "remote_prompt")
+                self._command(
+                    page,
+                    "injectAudio",
+                    {"index": audio_index, "trigger": "remote_prompt"},
+                )
                 gate.mark_injected()
                 return
             if (
@@ -196,12 +216,188 @@ class BrowserRunner:
                 and not gate.remote_activity_observed
                 and time.monotonic() >= fallback_deadline
             ):
-                self._command(page, "injectAudio", "initial_silence_fallback")
+                self._command(
+                    page,
+                    "injectAudio",
+                    {
+                        "index": audio_index,
+                        "trigger": "initial_silence_fallback",
+                    },
+                )
                 gate.mark_injected()
                 return
         raise RunFailure(
             "No completed remote prompt was detected before the prompt or call timeout"
         )
+
+    def _execute_steps(
+        self,
+        server: LocalRunServer,
+        page: Any,
+        call_deadline: float,
+    ) -> dict[str, Any]:
+        """Execute ordered Playwright-shaped action and expectation steps."""
+        step_results: list[dict[str, Any]] = []
+        observations: list[ResponseObservation] = []
+        last_injection: RunEvent | None = None
+        first_action = True
+
+        for step_index, step in enumerate(self.config.steps):
+            if isinstance(step, RunAction):
+                audio_index = step.audio_index
+                if first_action:
+                    self._wait_for_prompt_end(
+                        server,
+                        page,
+                        call_deadline,
+                        audio_index,
+                    )
+                    first_action = False
+                else:
+                    self._command(
+                        page,
+                        "injectAudio",
+                        {
+                            "index": audio_index,
+                            "trigger": "scenario_step",
+                        },
+                    )
+                last_injection = self._wait_for(
+                    server,
+                    lambda event, expected_index=audio_index: (
+                        event.name == "injection_finished"
+                        and event.details.get("injectionIndex")
+                        == expected_index
+                    ),
+                    self._bounded_timeout(30, call_deadline),
+                )
+                step_results.append(
+                    {
+                        "index": step_index,
+                        "kind": "action",
+                        "name": step.name,
+                        "audio_index": audio_index,
+                        "finished_timestamp": last_injection.timestamp,
+                    }
+                )
+                continue
+
+            if not isinstance(step, RunExpectation):
+                raise RunFailure(f"Unsupported scenario step: {step!r}")
+            if last_injection is None:
+                raise RunFailure("Expectation has no preceding caller injection")
+
+            if step.outcome == ExpectedOutcome.RESPONSE_START:
+                response_start = self._wait_for_response_start(
+                    server, call_deadline
+                )
+                step_results.append(
+                    {
+                        "index": step_index,
+                        "kind": "expect",
+                        "name": step.name,
+                        "outcome": step.outcome.value,
+                        "observed_timestamp": response_start.timestamp,
+                        "latency_seconds": max(
+                            0.0,
+                            response_start.timestamp - last_injection.timestamp,
+                        ),
+                    }
+                )
+                continue
+
+            observation = self._wait_for_remote_prompts(
+                server,
+                call_deadline,
+                last_injection,
+                wait_for_disconnect=(
+                    step.outcome == ExpectedOutcome.SESSION_END
+                ),
+                expected_response_prompts=step.response_prompts,
+            )
+            observations.append(observation)
+            step_results.append(
+                {
+                    "index": step_index,
+                    "kind": "expect",
+                    "name": step.name,
+                    "outcome": step.outcome.value,
+                    "observed_response_prompts": observation.prompt_count,
+                    "latency_seconds": observation.latency_seconds,
+                }
+            )
+
+            if step.outcome == ExpectedOutcome.SESSION_END:
+                disconnect = observation.disconnect_event
+                if disconnect is None:
+                    raise RunFailure(
+                        "WxCC did not disconnect after the successful "
+                        "task-completion response"
+                    )
+                return self._scenario_result(
+                    "remote_disconnect",
+                    observations,
+                    disconnect,
+                    step_results,
+                )
+            if step.outcome == ExpectedOutcome.TRANSFER:
+                if step.connected_observation_seconds > 0:
+                    self._assert_call_remains_connected(
+                        server,
+                        call_deadline,
+                        step.connected_observation_seconds,
+                    )
+
+        completion_reason, disconnect = self._end_call_locally(
+            server, page, call_deadline
+        )
+        return self._scenario_result(
+            completion_reason,
+            observations,
+            disconnect,
+            step_results,
+        )
+
+    def _wait_for_response_start(
+        self, server: LocalRunServer, call_deadline: float
+    ) -> RunEvent:
+        deadline = min(
+            time.monotonic() + self.config.response_timeout_seconds,
+            call_deadline,
+        )
+        while time.monotonic() < deadline:
+            event = self._next_event(
+                server, min(0.2, deadline - time.monotonic())
+            )
+            if event is None:
+                continue
+            if event.name == "remote_audio_active":
+                return event
+            if event.name == "disconnect":
+                raise RunFailure(
+                    "Call disconnected before remote response audio started"
+                )
+        raise RunFailure("No remote response audio started after caller injection")
+
+    @staticmethod
+    def _scenario_result(
+        completion_reason: str,
+        observations: list[ResponseObservation],
+        disconnect: RunEvent | None,
+        step_results: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        return {
+            "completion_reason": completion_reason,
+            "remote_response_observed": bool(observations),
+            "remote_response_latency_seconds": (
+                observations[-1].latency_seconds if observations else None
+            ),
+            "observed_remote_prompt_count": sum(
+                observation.prompt_count for observation in observations
+            ),
+            "disconnect": disconnect.details if disconnect else None,
+            "steps": step_results,
+        }
 
     def _wait_for_established(self, server: LocalRunServer, timeout: float) -> RunEvent:
         deadline = time.monotonic() + timeout
@@ -322,7 +518,13 @@ class BrowserRunner:
         injection_finished: RunEvent,
         *,
         wait_for_disconnect: bool = False,
+        expected_response_prompts: int | None = None,
     ) -> ResponseObservation:
+        required_prompts = (
+            self.config.expected_response_prompts
+            if expected_response_prompts is None
+            else expected_response_prompts
+        )
         deadline = min(
             time.monotonic() + self.config.response_timeout_seconds,
             call_deadline,
@@ -342,7 +544,7 @@ class BrowserRunner:
                     if wait_for_disconnect and first_active is not None:
                         if remote_active or quiet_since is not None:
                             prompt_count += 1
-                        if prompt_count >= self.config.expected_response_prompts:
+                        if prompt_count >= required_prompts:
                             return ResponseObservation(
                                 prompt_count=prompt_count,
                                 latency_seconds=max(
@@ -372,7 +574,7 @@ class BrowserRunner:
                 prompt_count += 1
                 quiet_since = None
                 if (
-                    prompt_count >= self.config.expected_response_prompts
+                    prompt_count >= required_prompts
                     and not wait_for_disconnect
                 ):
                     return ResponseObservation(
@@ -393,7 +595,7 @@ class BrowserRunner:
             )
         raise RunFailure(
             f"Observed {prompt_count} of "
-            f"{self.config.expected_response_prompts} required completed remote "
+            f"{required_prompts} required completed remote "
             "response prompt(s)"
         )
 
@@ -426,7 +628,7 @@ class BrowserRunner:
             raise RunFailure("Call timed out")
         return min(requested, remaining)
 
-    def _command(self, page: Any, command: str, argument: str | None = None) -> None:
+    def _command(self, page: Any, command: str, argument: Any = None) -> None:
         try:
             page.evaluate(
                 "payload => window.byovaE2E[payload.command](payload.argument)",

--- a/tools/byova_e2e/src/byova_e2e/server.py
+++ b/tools/byova_e2e/src/byova_e2e/server.py
@@ -16,7 +16,7 @@ from .models import RunConfig, RunEvent
 
 
 class LocalRunServer:
-    """Serve the compiled client, one prepared WAV, and an event endpoint."""
+    """Serve the compiled client, prepared WAVs, and an event endpoint."""
 
     def __init__(self, static_root: Path, config: RunConfig) -> None:
         self._static_root = static_root
@@ -47,6 +47,7 @@ class LocalRunServer:
     def _handler_type(self) -> type[SimpleHTTPRequestHandler]:
         static_root = self._static_root
         config = self._config
+        audio_assets = config.prepared_audio()
         events = self._events
 
         class Handler(SimpleHTTPRequestHandler):
@@ -62,11 +63,31 @@ class LocalRunServer:
                         "accessToken": config.access_token,
                         "destination": config.destination,
                         "audioUrl": "/run/caller.wav",
+                        "audioUrls": [
+                            f"/run/caller-{index}.wav"
+                            for index in range(len(audio_assets))
+                        ],
                     }
                     self._write_json(payload)
                     return
                 if self.path == "/run/caller.wav":
-                    self._send_audio(config.audio_path)
+                    self._send_audio(audio_assets[0].path)
+                    return
+                if self.path.startswith("/run/caller-") and self.path.endswith(
+                    ".wav"
+                ):
+                    index_text = self.path.removeprefix(
+                        "/run/caller-"
+                    ).removesuffix(".wav")
+                    try:
+                        index = int(index_text)
+                        if index < 0:
+                            raise IndexError
+                        audio_asset = audio_assets[index]
+                    except (ValueError, IndexError):
+                        self.send_error(HTTPStatus.NOT_FOUND)
+                        return
+                    self._send_audio(audio_asset.path)
                     return
                 super().do_GET()
 

--- a/tools/byova_e2e/tests/test_cli.py
+++ b/tools/byova_e2e/tests/test_cli.py
@@ -2,7 +2,9 @@ import json
 from pathlib import Path
 
 import pytest
+from byova_e2e.audio import PreparedAudio
 from byova_e2e.cli import CLIError, _run, build_parser, main
+from byova_e2e.models import ExpectedOutcome, RunAction, RunExpectation
 
 
 def test_live_runs_have_no_cli_browser_override_by_default() -> None:
@@ -88,3 +90,78 @@ def test_validate_lists_plan_without_authentication(
     assert "Validated 1 test(s)" in output
     assert "request-response: receives one response" in output
     assert "sha256:" in output
+
+
+def test_named_multi_turn_test_prepares_every_action(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config_file = tmp_path / "connector.spec.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "tests": [
+                    {
+                        "id": "multi-turn",
+                        "title": "completes two turns",
+                        "steps": [
+                            {"action": "speak", "text": "I need a hotel."},
+                            {"expect": {"outcome": "response"}},
+                            {
+                                "action": "speak",
+                                "text": "A queen room, please.",
+                            },
+                            {"expect": {"outcome": "response"}},
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    rendered_text: list[str] = []
+    captured_config = None
+
+    def fake_render_text(text, _voice, output_path):
+        rendered_text.append(text)
+        output_path.write_bytes(text.encode())
+        return PreparedAudio(output_path, str(len(rendered_text)) * 64, 1)
+
+    class FakeRunner:
+        def __init__(self, _tool_root, config):
+            nonlocal captured_config
+            captured_config = config
+
+        def run(self):
+            return {}
+
+    monkeypatch.setattr("byova_e2e.cli.render_text", fake_render_text)
+    monkeypatch.setattr("byova_e2e.cli.access_token_for_run", lambda _store: "token")
+    monkeypatch.setattr("byova_e2e.cli.BrowserRunner", FakeRunner)
+    monkeypatch.setattr(
+        "byova_e2e.cli.write_artifact",
+        lambda _directory, _payload: tmp_path / "artifact.json",
+    )
+    args = build_parser().parse_args(
+        [
+            "run",
+            "--destination",
+            "9999",
+            "--config",
+            str(config_file),
+            "--test",
+            "multi-turn",
+        ]
+    )
+
+    _run(args)
+
+    assert rendered_text == ["I need a hotel.", "A queen room, please."]
+    assert captured_config is not None
+    assert len(captured_config.prepared_audio()) == 2
+    assert captured_config.steps == (
+        RunAction(0),
+        RunExpectation(ExpectedOutcome.RESPONSE),
+        RunAction(1),
+        RunExpectation(ExpectedOutcome.RESPONSE),
+    )

--- a/tools/byova_e2e/tests/test_runner.py
+++ b/tools/byova_e2e/tests/test_runner.py
@@ -205,10 +205,10 @@ def test_injects_second_utterance_after_response_audio_starts(tmp_path) -> None:
             RunEvent("remote_audio_inactive", 2.0),
             RunEvent("injection_finished", 3.0, {"injectionIndex": 0}),
             RunEvent("remote_audio_active", 4.0),
+            RunEvent("remote_audio_inactive", 4.2),
+            RunEvent("remote_audio_active", 4.4),
+            RunEvent("remote_audio_inactive", 4.8),
             RunEvent("injection_finished", 5.0, {"injectionIndex": 1}),
-            RunEvent("remote_audio_inactive", 6.0),
-            RunEvent("remote_audio_active", 7.0),
-            RunEvent("remote_audio_inactive", 8.0),
             RunEvent("disconnect", 9.0, {"initiatedByCaller": True}),
         ]
     )
@@ -225,6 +225,7 @@ def test_injects_second_utterance_after_response_audio_starts(tmp_path) -> None:
     }
     assert result["steps"][1]["outcome"] == "response-start"
     assert result["observed_remote_prompt_count"] == 1
+    assert result["steps"][3]["latency_seconds"] == 0
 
 
 def test_required_remote_response_records_latency_and_waits_for_quiet(

--- a/tools/byova_e2e/tests/test_runner.py
+++ b/tools/byova_e2e/tests/test_runner.py
@@ -4,7 +4,14 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
-from byova_e2e.models import ExpectedOutcome, RunConfig, RunEvent
+from byova_e2e.models import (
+    AudioAsset,
+    ExpectedOutcome,
+    RunAction,
+    RunConfig,
+    RunEvent,
+    RunExpectation,
+)
 from byova_e2e.runner import BrowserRunner, RunFailure
 from playwright.sync_api import Error as PlaywrightError
 
@@ -95,6 +102,129 @@ class _EventServer:
 
     def next_event(self, _timeout: float) -> RunEvent | None:
         return self.events.pop(0) if self.events else None
+
+
+class _CommandPage:
+    def __init__(self) -> None:
+        self.commands: list[dict[str, object]] = []
+
+    def evaluate(self, _script: str, payload: dict[str, object]) -> None:
+        self.commands.append(payload)
+
+
+def _audio_assets(tmp_path: Path, count: int) -> tuple[AudioAsset, ...]:
+    return tuple(
+        AudioAsset(
+            path=tmp_path / f"caller-{index}.wav",
+            sha256=str(index) * 64,
+            duration_seconds=1,
+        )
+        for index in range(count)
+    )
+
+
+def test_executes_two_request_response_turns_in_order(tmp_path) -> None:
+    config = replace(
+        _config(tmp_path),
+        audio_assets=_audio_assets(tmp_path, 2),
+        steps=(
+            RunAction(0, "First request"),
+            RunExpectation(ExpectedOutcome.RESPONSE, name="First response"),
+            RunAction(1, "Second request"),
+            RunExpectation(ExpectedOutcome.RESPONSE, name="Second response"),
+        ),
+        response_timeout_seconds=1,
+        remote_silence_seconds=0,
+    )
+    runner = BrowserRunner(tmp_path, config)
+    page = _CommandPage()
+    server = _EventServer(
+        [
+            RunEvent("remote_audio_active", 1.0),
+            RunEvent("remote_audio_inactive", 2.0),
+            RunEvent("injection_finished", 3.0, {"injectionIndex": 0}),
+            RunEvent("remote_audio_active", 4.0),
+            RunEvent("remote_audio_inactive", 5.0),
+            RunEvent("injection_finished", 6.0, {"injectionIndex": 1}),
+            RunEvent("remote_audio_active", 7.0),
+            RunEvent("remote_audio_inactive", 8.0),
+            RunEvent(
+                "disconnect",
+                9.0,
+                {"initiatedByCaller": True},
+            ),
+        ]
+    )
+
+    result = runner._execute_steps(
+        server,
+        page,
+        time.monotonic() + 2,
+    )
+
+    assert [command["command"] for command in page.commands] == [
+        "injectAudio",
+        "injectAudio",
+        "endCall",
+    ]
+    assert page.commands[0]["argument"] == {
+        "index": 0,
+        "trigger": "remote_prompt",
+    }
+    assert page.commands[1]["argument"] == {
+        "index": 1,
+        "trigger": "scenario_step",
+    }
+    assert result["observed_remote_prompt_count"] == 2
+    assert [step["kind"] for step in result["steps"]] == [
+        "action",
+        "expect",
+        "action",
+        "expect",
+    ]
+
+
+def test_injects_second_utterance_after_response_audio_starts(tmp_path) -> None:
+    config = replace(
+        _config(tmp_path),
+        audio_assets=_audio_assets(tmp_path, 2),
+        steps=(
+            RunAction(0),
+            RunExpectation(ExpectedOutcome.RESPONSE_START),
+            RunAction(1),
+            RunExpectation(ExpectedOutcome.RESPONSE),
+        ),
+        response_timeout_seconds=1,
+        remote_silence_seconds=0,
+    )
+    runner = BrowserRunner(tmp_path, config)
+    page = _CommandPage()
+    server = _EventServer(
+        [
+            RunEvent("remote_audio_active", 1.0),
+            RunEvent("remote_audio_inactive", 2.0),
+            RunEvent("injection_finished", 3.0, {"injectionIndex": 0}),
+            RunEvent("remote_audio_active", 4.0),
+            RunEvent("injection_finished", 5.0, {"injectionIndex": 1}),
+            RunEvent("remote_audio_inactive", 6.0),
+            RunEvent("remote_audio_active", 7.0),
+            RunEvent("remote_audio_inactive", 8.0),
+            RunEvent("disconnect", 9.0, {"initiatedByCaller": True}),
+        ]
+    )
+
+    result = runner._execute_steps(
+        server,
+        page,
+        time.monotonic() + 2,
+    )
+
+    assert page.commands[1]["argument"] == {
+        "index": 1,
+        "trigger": "scenario_step",
+    }
+    assert result["steps"][1]["outcome"] == "response-start"
+    assert result["observed_remote_prompt_count"] == 1
 
 
 def test_required_remote_response_records_latency_and_waits_for_quiet(

--- a/tools/byova_e2e/tests/test_server.py
+++ b/tools/byova_e2e/tests/test_server.py
@@ -1,8 +1,9 @@
 import json
+from dataclasses import replace
 from pathlib import Path
 from urllib.request import Request, urlopen
 
-from byova_e2e.models import RunConfig
+from byova_e2e.models import AudioAsset, RunConfig
 from byova_e2e.server import LocalRunServer
 
 
@@ -53,3 +54,38 @@ def test_browser_event_receives_utc_correlation_timestamp(tmp_path) -> None:
     assert event.timestamp == 12.5
     assert event.received_at_utc is not None
     assert event.received_at_utc.endswith("+00:00")
+
+
+def test_server_exposes_each_prepared_audio_asset(tmp_path) -> None:
+    first = tmp_path / "first.wav"
+    second = tmp_path / "second.wav"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    config = replace(
+        _config(tmp_path),
+        audio_assets=(
+            AudioAsset(first, "1" * 64, 1),
+            AudioAsset(second, "2" * 64, 1),
+        ),
+    )
+    static_root = tmp_path / "static"
+    static_root.mkdir()
+    server = LocalRunServer(static_root, config)
+    server.start()
+    try:
+        with urlopen(f"{server.url}api/config") as response:
+            browser_config = json.load(response)
+        with urlopen(f"{server.url}run/caller.wav") as response:
+            legacy_audio = response.read()
+        with urlopen(f"{server.url}run/caller-1.wav") as response:
+            second_audio = response.read()
+    finally:
+        server.close()
+
+    assert browser_config["audioUrls"] == [
+        "/run/caller-0.wav",
+        "/run/caller-1.wav",
+    ]
+    assert browser_config["audioUrl"] == "/run/caller.wav"
+    assert legacy_audio == b"first"
+    assert second_audio == b"second"

--- a/tools/byova_e2e/tests/test_test_plan.py
+++ b/tools/byova_e2e/tests/test_test_plan.py
@@ -4,8 +4,15 @@ from pathlib import Path
 
 import pytest
 from byova_e2e.models import ExpectedOutcome
-from byova_e2e.plan import TestPlanError as PlanError
-from byova_e2e.plan import load_plan, load_test
+from byova_e2e.plan import (
+    ExpectStepDefinition,
+    InputStepDefinition,
+    load_plan,
+    load_test,
+)
+from byova_e2e.plan import (
+    TestPlanError as PlanError,
+)
 
 
 def _write_plan(
@@ -100,6 +107,61 @@ def test_resolves_play_fixture_relative_to_config(tmp_path: Path) -> None:
     selected_test = load_test("sample", path)
 
     assert selected_test.wav == (tmp_path / "fixtures/request.wav").resolve()
+
+
+def test_loads_ordered_multi_injection_steps(tmp_path: Path) -> None:
+    path = _write_plan(
+        tmp_path,
+        steps=[
+            {"action": "speak", "text": "I need a hotel."},
+            {"expect": {"outcome": "response"}},
+            {"action": "speak", "text": "A queen room, please."},
+            {"expect": {"outcome": "response"}},
+        ],
+    )
+
+    selected_test = load_test("sample", path)
+
+    assert selected_test.steps == (
+        InputStepDefinition(text="I need a hotel."),
+        ExpectStepDefinition(outcome=ExpectedOutcome.RESPONSE),
+        InputStepDefinition(text="A queen room, please."),
+        ExpectStepDefinition(outcome=ExpectedOutcome.RESPONSE),
+    )
+
+
+def test_loads_response_start_gate_for_speaking_during_playback(
+    tmp_path: Path,
+) -> None:
+    path = _write_plan(
+        tmp_path,
+        steps=[
+            {"action": "speak", "text": "Tell me about the room."},
+            {"expect": {"outcome": "response-start"}},
+            {"action": "speak", "text": "I also need late checkout."},
+            {"expect": {"outcome": "response"}},
+        ],
+    )
+
+    selected_test = load_test("sample", path)
+
+    assert selected_test.steps[1] == ExpectStepDefinition(
+        outcome=ExpectedOutcome.RESPONSE_START
+    )
+
+
+def test_rejects_consecutive_actions_without_an_expectation(tmp_path: Path) -> None:
+    path = _write_plan(
+        tmp_path,
+        steps=[
+            {"action": "speak", "text": "First"},
+            {"action": "speak", "text": "Second"},
+            {"expect": {"outcome": "response"}},
+        ],
+    )
+
+    with pytest.raises(PlanError, match="must alternate audio actions and expectations"):
+        load_test("sample", path)
 
 
 def test_rejects_unknown_fields_to_catch_misspellings(tmp_path: Path) -> None:

--- a/tools/byova_e2e/web/src/main.ts
+++ b/tools/byova_e2e/web/src/main.ts
@@ -8,9 +8,14 @@ type RunConfig = {
   accessToken: string;
   destination: string;
   audioUrl: string;
+  audioUrls?: string[];
 };
 
 type EventDetails = Record<string, string | number | boolean | undefined>;
+type InjectionRequest = {
+  index?: number;
+  trigger?: string;
+};
 
 type CallingLine = {
   on: (name: string, callback: (...args: unknown[]) => void) => void;
@@ -49,7 +54,7 @@ declare global {
   interface Window {
     byovaE2E: {
       dial: () => Promise<void>;
-      injectAudio: (trigger?: string) => Promise<void>;
+      injectAudio: (request?: string | InjectionRequest) => Promise<void>;
       endCall: () => Promise<void>;
     };
   }
@@ -147,7 +152,7 @@ class CallingMediaClient {
   private line!: CallingLine;
   private call?: CallingCall;
   private observer?: RemoteAudioActivity;
-  private injected = false;
+  private readonly injectedAudio = new Set<number>();
   private callerEndRequested = false;
 
   async initialise(): Promise<void> {
@@ -243,15 +248,27 @@ class CallingMediaClient {
     await this.call.dial(this.localMicrophone);
   }
 
-  async injectAudio(trigger = "remote_prompt"): Promise<void> {
+  async injectAudio(request: string | InjectionRequest = {}): Promise<void> {
     if (!this.call) {
       throw new Error("Cannot inject audio before dialing");
     }
-    if (this.injected) {
-      throw new Error("The test caller only supports one injected utterance per call");
+    const injection = typeof request === "string" ? { trigger: request } : request;
+    const index = injection.index ?? 0;
+    const trigger = injection.trigger ?? "scenario_step";
+    if (!Number.isInteger(index) || index < 0) {
+      throw new Error(`Invalid caller audio index: ${index}`);
     }
-    this.injected = true;
-    const response = await fetch(this.config.audioUrl);
+    if (this.injectedAudio.has(index)) {
+      throw new Error(`Caller audio ${index} was already injected`);
+    }
+    const audioUrl = this.config.audioUrls?.[index] ?? (
+      index === 0 ? this.config.audioUrl : undefined
+    );
+    if (!audioUrl) {
+      throw new Error(`No prepared caller audio exists at index ${index}`);
+    }
+    this.injectedAudio.add(index);
+    const response = await fetch(audioUrl);
     if (!response.ok) {
       throw new Error(`Cannot load prepared caller audio: ${response.status}`);
     }
@@ -260,9 +277,17 @@ class CallingMediaClient {
     const source = this.audioContext.createBufferSource();
     source.buffer = audio;
     source.connect(this.destinationNode);
-    source.addEventListener("ended", () => void report("injection_finished"), { once: true });
+    source.addEventListener(
+      "ended",
+      () => void report("injection_finished", { injectionIndex: index }),
+      { once: true },
+    );
     updateStatus("Injecting prepared caller audio.");
-    void report("injection_started", { durationSeconds: audio.duration, trigger });
+    void report("injection_started", {
+      durationSeconds: audio.duration,
+      injectionIndex: index,
+      trigger,
+    });
     source.start();
   }
 


### PR DESCRIPTION
## Summary
- allow Playwright-shaped plans to alternate caller audio actions and expectations
- add a `response-start` gate for injecting the next utterance while remote audio is active
- serve indexed prepared audio assets while preserving the legacy single-audio endpoint
- record per-step execution evidence in E2E artifacts

## Validation
- 46 Python E2E tests passed
- 4 browser tests passed
- TypeScript and Vite production build passed
- Ruff and `git diff --check` passed

This is provider-neutral test-runner infrastructure. GECX-specific Phase 2 scenarios will remain on the GECX feature branch after this PR lands.