### PR TITLE
fix(e2e): persist and refresh OAuth tokens

### DIFF
--- a/tools/byova_e2e/.env.example
+++ b/tools/byova_e2e/.env.example
@@ -5,3 +5,5 @@ BYOVA_E2E_WEBEX_CLIENT_SECRET=
 BYOVA_E2E_WEBEX_REDIRECT_URI=http://localhost:8765/oauth/callback
 BYOVA_E2E_TEST_USER_EMAIL=your-dedicated-calling-user@example.com
 BYOVA_E2E_TEST_USER_NAME=BYOVA E2E Test Caller
+# Optional: override the shared user-level OAuth token location.
+# BYOVA_E2E_WEBEX_TOKEN_PATH=/absolute/path/to/oauth-token.json

--- a/tools/byova_e2e/README.md
+++ b/tools/byova_e2e/README.md
@@ -124,10 +124,23 @@ Chrome profile, sign in as the `BYOVA_E2E_TEST_USER_EMAIL` configured in
 When `BYOVA_E2E_TEST_USER_EMAIL` is set, the authorization request explicitly
 selects an account and supplies that email as the login hint so an existing
 administrator session cannot be accepted accidentally.
-The returned access and refresh tokens are written only to ignored
-`.state/oauth-token.json` with owner-only permissions and refreshed on later
-runs. A temporary `BYOVA_E2E_WEBEX_ACCESS_TOKEN` environment value can instead
-be used for a single run.
+The returned access and refresh tokens are written to the user-level
+`$XDG_STATE_HOME/byova-e2e/oauth-token.json` (or
+`~/.local/state/byova-e2e/oauth-token.json`) with owner-only permissions. This
+location is shared across repository clones and worktrees. An existing
+checkout-local `.state/oauth-token.json` is copied to the shared location on
+its next use.
+
+On later runs, the tool uses the saved access token while it is valid. When it
+expires, the tool exchanges the saved refresh token for a new token pair and
+atomically saves the response, including any rotated refresh token. This keeps
+the dedicated test user authorized without another browser consent. A new
+`byova-e2e login` is required only if the refresh token expires or is revoked,
+or if the OAuth integration credentials change. Set
+`BYOVA_E2E_WEBEX_TOKEN_PATH` to an absolute path to override the shared
+location. A temporary `BYOVA_E2E_WEBEX_ACCESS_TOKEN` environment value can
+instead be used for a single run; because it has no associated refresh token,
+it is not persisted.
 
 ```bash
 byova-e2e run --destination 9999 --text 'Hello, this is a BYOVA test.'

--- a/tools/byova_e2e/src/byova_e2e/auth.py
+++ b/tools/byova_e2e/src/byova_e2e/auth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import secrets
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
@@ -20,10 +21,26 @@ AUTHORIZE_URL = "https://webexapis.com/v1/authorize"
 TOKEN_URL = "https://webexapis.com/v1/access_token"
 SCOPES = ("spark:xsi", "spark:calls_write", "spark:calls_read", "spark:webrtc_calling")
 TOKEN_EXPIRY_SKEW_SECONDS = 60
+TOKEN_PATH_ENVIRONMENT_VARIABLE = "BYOVA_E2E_WEBEX_TOKEN_PATH"
 
 
 class OAuthError(RuntimeError):
     """An OAuth configuration, callback, or token-exchange failure."""
+
+
+def default_token_path() -> Path:
+    """Return a user-level token path shared by repository worktrees."""
+    if configured_path := os.environ.get(TOKEN_PATH_ENVIRONMENT_VARIABLE):
+        token_path = Path(configured_path).expanduser()
+        if not token_path.is_absolute():
+            raise OAuthError(
+                f"${TOKEN_PATH_ENVIRONMENT_VARIABLE} must be an absolute path"
+            )
+        return token_path
+    state_root = Path(
+        os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state")
+    ).expanduser()
+    return state_root / "byova-e2e" / "oauth-token.json"
 
 
 def load_local_environment(path: Path) -> None:
@@ -87,33 +104,54 @@ class OAuthCredentials:
 class OAuthTokenStore:
     """Persist refreshable OAuth credentials with owner-only file permissions."""
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, legacy_path: Path | None = None) -> None:
         self.path = path
+        self.legacy_path = legacy_path
 
     def load(self) -> dict[str, Any] | None:
-        if not self.path.is_file():
+        if self.path.is_file():
+            return self._load_path(self.path)
+        if self.legacy_path is None or not self.legacy_path.is_file():
             return None
+        payload = self._load_path(self.legacy_path)
+        self.save(payload)
+        return payload
+
+    def _load_path(self, path: Path) -> dict[str, Any]:
         try:
-            payload = json.loads(self.path.read_text(encoding="utf-8"))
+            payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as error:
             raise OAuthError(
-                f"Cannot read saved OAuth token at {self.path}: {error}"
+                f"Cannot read saved OAuth token at {path}: {error}"
             ) from error
         if not isinstance(payload, dict) or not isinstance(
             payload.get("access_token"), str
         ):
-            raise OAuthError(f"Saved OAuth token at {self.path} is invalid")
+            raise OAuthError(f"Saved OAuth token at {path} is invalid")
         return payload
 
     def save(self, token: dict[str, Any]) -> None:
+        parent_exists = self.path.parent.exists()
         self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        temporary = self.path.with_suffix(".tmp")
-        temporary.write_text(
-            json.dumps(token, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-        )
-        temporary.chmod(0o600)
-        temporary.replace(self.path)
-        self.path.chmod(0o600)
+        if not parent_exists:
+            self.path.parent.chmod(0o700)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=self.path.parent,
+                prefix=f".{self.path.name}.",
+                delete=False,
+            ) as temporary:
+                temporary_path = Path(temporary.name)
+                temporary.write(json.dumps(token, indent=2, sort_keys=True) + "\n")
+            temporary_path.chmod(0o600)
+            temporary_path.replace(self.path)
+            self.path.chmod(0o600)
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
 
 
 def authorization_url(
@@ -178,8 +216,9 @@ def access_token_for_run(store: OAuthTokenStore) -> str:
             "Saved OAuth token has expired and has no refresh token; run `byova-e2e login`"
         )
     refreshed = refresh_token(OAuthCredentials.from_environment(), refresh)
-    store.save(refreshed)
-    return str(refreshed["access_token"])
+    saved_token = _merge_refreshed_token(token, refreshed)
+    store.save(saved_token)
+    return str(saved_token["access_token"])
 
 
 def complete_login(store: OAuthTokenStore, timeout_seconds: float) -> str:
@@ -200,7 +239,16 @@ def complete_login(store: OAuthTokenStore, timeout_seconds: float) -> str:
             )
         )
         code = callback.wait_for_code(state, timeout_seconds)
-        store.save(exchange_code(credentials, code))
+        token = exchange_code(credentials, code)
+        if (
+            not isinstance(token.get("refresh_token"), str)
+            or not token["refresh_token"]
+        ):
+            raise OAuthError(
+                "Webex OAuth response did not contain a refresh token; "
+                "the authorization was not saved"
+            )
+        store.save(token)
         return str(store.path)
     finally:
         callback.close()
@@ -215,8 +263,22 @@ def _request_token(payload: dict[str, str]) -> dict[str, Any]:
         raise OAuthError(f"Webex OAuth token request failed: {error}") from error
     if not isinstance(token, dict) or not isinstance(token.get("access_token"), str):
         raise OAuthError("Webex OAuth response did not contain an access token")
-    token["expires_at"] = time.time() + float(token.get("expires_in", 0))
+    received_at = time.time()
+    token["expires_at"] = received_at + float(token.get("expires_in", 0))
     return token
+
+
+def _merge_refreshed_token(
+    previous: dict[str, Any], refreshed: dict[str, Any]
+) -> dict[str, Any]:
+    """Keep a usable refresh token while preferring any rotated token response."""
+    merged = {**previous, **refreshed}
+    if (
+        not isinstance(refreshed.get("refresh_token"), str)
+        or not refreshed["refresh_token"]
+    ):
+        merged["refresh_token"] = previous["refresh_token"]
+    return merged
 
 
 class OAuthCallbackServer:

--- a/tools/byova_e2e/src/byova_e2e/cli.py
+++ b/tools/byova_e2e/src/byova_e2e/cli.py
@@ -21,6 +21,7 @@ from .auth import (
     OAuthTokenStore,
     access_token_for_run,
     complete_login,
+    default_token_path,
     load_local_environment,
 )
 from .models import ExpectedOutcome, RunConfig
@@ -34,7 +35,7 @@ from .runner import BrowserRunner, RunFailure
 
 DESTINATION_PATTERN = re.compile(r"^(?:tel:)?\+?[0-9]{2,20}$")
 TOOL_ROOT = Path(__file__).resolve().parents[2]
-TOKEN_PATH = TOOL_ROOT / ".state" / "oauth-token.json"
+LEGACY_TOKEN_PATH = TOOL_ROOT / ".state" / "oauth-token.json"
 T = TypeVar("T")
 
 
@@ -167,9 +168,7 @@ def main(argv: list[str] | None = None) -> None:
         if args.command == "login":
             if args.timeout_seconds <= 0:
                 raise CLIError("--timeout-seconds must be greater than zero")
-            token_path = complete_login(
-                OAuthTokenStore(TOKEN_PATH), args.timeout_seconds
-            )
+            token_path = complete_login(_oauth_token_store(), args.timeout_seconds)
             print(f"Webex OAuth authorization saved locally at {token_path}")
             return
         if args.command == "validate":
@@ -219,6 +218,10 @@ def main(argv: list[str] | None = None) -> None:
 
 class CLIError(ValueError):
     """A validated user-facing CLI input failure."""
+
+
+def _oauth_token_store() -> OAuthTokenStore:
+    return OAuthTokenStore(default_token_path(), legacy_path=LEGACY_TOKEN_PATH)
 
 
 def _run(args: argparse.Namespace) -> None:
@@ -321,7 +324,7 @@ def _run(args: argparse.Namespace) -> None:
         if segment_pause_ms <= 0:
             raise CLIError("--segment-pause-ms must be greater than zero")
 
-    token = access_token_for_run(OAuthTokenStore(TOKEN_PATH))
+    token = access_token_for_run(_oauth_token_store())
     with tempfile.TemporaryDirectory(prefix="byova-e2e-") as temp_dir:
         audio_path = Path(temp_dir) / "caller.wav"
         if text is not None:

--- a/tools/byova_e2e/tests/test_auth.py
+++ b/tools/byova_e2e/tests/test_auth.py
@@ -1,13 +1,18 @@
 import os
 import stat
+import time
 from urllib.parse import parse_qs, urlparse
 
+import pytest
 from byova_e2e.auth import (
     SCOPES,
     OAuthCredentials,
+    OAuthError,
     OAuthTokenStore,
     access_token_for_run,
     authorization_url,
+    complete_login,
+    default_token_path,
     load_local_environment,
 )
 
@@ -49,7 +54,43 @@ def test_token_store_uses_owner_only_permissions(tmp_path) -> None:
     store.save({"access_token": "test-token", "expires_at": 9999999999})
 
     assert store.load() == {"access_token": "test-token", "expires_at": 9999999999}
+    assert stat.S_IMODE(store.path.parent.stat().st_mode) == 0o700
     assert stat.S_IMODE(store.path.stat().st_mode) == 0o600
+
+
+def test_default_token_path_is_user_level_and_shared_across_worktrees(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.delenv("BYOVA_E2E_WEBEX_TOKEN_PATH", raising=False)
+
+    assert default_token_path() == (
+        tmp_path / "state" / "byova-e2e" / "oauth-token.json"
+    )
+
+
+def test_default_token_path_honors_explicit_override(tmp_path, monkeypatch) -> None:
+    configured_path = tmp_path / "credentials" / "test-user.json"
+    monkeypatch.setenv("BYOVA_E2E_WEBEX_TOKEN_PATH", str(configured_path))
+
+    assert default_token_path() == configured_path
+
+
+def test_token_store_migrates_legacy_worktree_state(tmp_path) -> None:
+    legacy_store = OAuthTokenStore(tmp_path / "worktree" / ".state" / "token.json")
+    token = {
+        "access_token": "legacy-access-token",
+        "refresh_token": "legacy-refresh-token",
+        "expires_at": 9999999999,
+    }
+    legacy_store.save(token)
+    shared_store = OAuthTokenStore(
+        tmp_path / "shared" / "token.json", legacy_path=legacy_store.path
+    )
+
+    assert shared_store.load() == token
+    assert shared_store.path.is_file()
+    assert stat.S_IMODE(shared_store.path.stat().st_mode) == 0o600
 
 
 def test_access_token_environment_override_does_not_touch_store(
@@ -59,6 +100,102 @@ def test_access_token_environment_override_does_not_touch_store(
     monkeypatch.setenv("BYOVA_E2E_WEBEX_ACCESS_TOKEN", "override-token")
 
     assert access_token_for_run(store) == "override-token"
+    assert not store.path.exists()
+
+
+def test_expired_access_token_uses_and_saves_rotated_refresh_token(
+    tmp_path, monkeypatch
+) -> None:
+    store = OAuthTokenStore(tmp_path / "token.json")
+    store.save(
+        {
+            "access_token": "expired-access-token",
+            "refresh_token": "original-refresh-token",
+            "expires_at": time.time() - 1,
+        }
+    )
+    monkeypatch.setenv("BYOVA_E2E_WEBEX_CLIENT_ID", "client")
+    monkeypatch.setenv("BYOVA_E2E_WEBEX_CLIENT_SECRET", "secret")
+    refreshes = []
+
+    def fake_refresh(_credentials, refresh):
+        refreshes.append(refresh)
+        return {
+            "access_token": "new-access-token",
+            "refresh_token": "rotated-refresh-token",
+            "expires_at": time.time() + 3600,
+        }
+
+    monkeypatch.setattr("byova_e2e.auth.refresh_token", fake_refresh)
+
+    assert access_token_for_run(store) == "new-access-token"
+    assert refreshes == ["original-refresh-token"]
+    assert store.load()["refresh_token"] == "rotated-refresh-token"
+
+
+def test_refresh_response_without_refresh_token_keeps_previous_token(
+    tmp_path, monkeypatch
+) -> None:
+    store = OAuthTokenStore(tmp_path / "token.json")
+    store.save(
+        {
+            "access_token": "expired-access-token",
+            "refresh_token": "reusable-refresh-token",
+            "expires_at": time.time() - 1,
+        }
+    )
+    monkeypatch.setenv("BYOVA_E2E_WEBEX_CLIENT_ID", "client")
+    monkeypatch.setenv("BYOVA_E2E_WEBEX_CLIENT_SECRET", "secret")
+    monkeypatch.setattr(
+        "byova_e2e.auth.refresh_token",
+        lambda _credentials, _refresh: {
+            "access_token": "new-access-token",
+            "expires_at": time.time() + 3600,
+        },
+    )
+
+    assert access_token_for_run(store) == "new-access-token"
+    assert store.load()["refresh_token"] == "reusable-refresh-token"
+
+
+def test_complete_login_persists_access_and_refresh_tokens(
+    tmp_path, monkeypatch
+) -> None:
+    store = OAuthTokenStore(tmp_path / "token.json")
+    monkeypatch.setenv("BYOVA_E2E_WEBEX_CLIENT_ID", "client")
+    monkeypatch.setenv("BYOVA_E2E_WEBEX_CLIENT_SECRET", "secret")
+    monkeypatch.setattr("byova_e2e.auth.OAuthCallbackServer", FakeOAuthCallback)
+    monkeypatch.setattr(
+        "byova_e2e.auth.exchange_code",
+        lambda _credentials, _code: {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_at": time.time() + 3600,
+        },
+    )
+
+    assert complete_login(store, 30) == str(store.path)
+    assert store.load()["refresh_token"] == "refresh-token"
+
+
+def test_complete_login_rejects_non_refreshable_authorization(
+    tmp_path, monkeypatch
+) -> None:
+    store = OAuthTokenStore(tmp_path / "token.json")
+    monkeypatch.setenv("BYOVA_E2E_WEBEX_CLIENT_ID", "client")
+    monkeypatch.setenv("BYOVA_E2E_WEBEX_CLIENT_SECRET", "secret")
+    monkeypatch.setattr("byova_e2e.auth.OAuthCallbackServer", FakeOAuthCallback)
+    monkeypatch.setattr(
+        "byova_e2e.auth.exchange_code",
+        lambda _credentials, _code: {
+            "access_token": "access-token",
+            "expires_at": time.time() + 3600,
+        },
+    )
+
+    with pytest.raises(OAuthError, match="did not contain a refresh token"):
+        complete_login(store, 30)
+
     assert not store.path.exists()
 
 
@@ -91,3 +228,17 @@ def test_local_environment_rejects_unrelated_variables(tmp_path) -> None:
         raise AssertionError(
             "Expected local environment loader to reject unrelated variables"
         )
+
+
+class FakeOAuthCallback:
+    def __init__(self, _redirect_uri) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+    def wait_for_code(self, _state, _timeout_seconds) -> str:
+        return "authorization-code"
+
+    def close(self) -> None:
+        pass


### PR DESCRIPTION
## Summary

- store the BYOVA E2E OAuth token pair in user-level state shared across repository clones and worktrees
- migrate an existing checkout-local token file and keep token writes atomic with owner-only permissions
- use the saved refresh token when the access token expires, persist rotated refresh tokens, and preserve the prior token if a refresh response omits it
- document the shared location and optional `BYOVA_E2E_WEBEX_TOKEN_PATH` override

## Why

OAuth state was stored under the current checkout, so moving to another worktree made the dedicated test caller appear unauthenticated. Refresh responses also replaced the complete saved payload, which could discard the reusable refresh token if the response omitted it.

## User impact

After one successful `byova-e2e login`, later runs and other worktrees reuse the dedicated test user's authorization. Browser consent is only needed again when the refresh token expires or is revoked, or when the integration credentials change.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 tools/byova_e2e/.venv/bin/python -m pytest tools/byova_e2e/tests -q` — 46 passed
- `ruff check` on the changed Python files
- `ruff format --check` on the changed Python files
- `git diff --check upstream/main...HEAD`
