### PR TITLE
feat(gateway): add Phase 2 full-duplex plumbing

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -97,7 +97,8 @@ webex-byova-gateway-python/
 
 - Implements the `VoiceVirtualAgentServicer` gRPC interface
 - Manages conversation state through `ConversationProcessor` instances
-- Handles bidirectional streaming for voice interactions
+- Handles bidirectional streaming with bounded request and response queues so caller input
+  ingestion remains independent from ordered connector response production
 - Routes requests to the appropriate virtual agent via `VirtualAgentRouter`
 - Tracks connections and manages session lifecycle
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ For Google CX Agent Studio, use the
 At runtime, WxCC opens a bidirectional gRPC stream to the registered gateway endpoint. The
 gateway validates the signed Webex token, routes the conversation to the configured
 connector, and translates audio and events between WxCC and the voice-agent provider.
+Caller ingestion, ordered connector processing, and response delivery use independent
+workers with bounded per-stream queues, so WxCC can continue sending caller frames while a
+connector is still producing output.
 
 The sample includes:
 

--- a/config/README.md
+++ b/config/README.md
@@ -14,14 +14,24 @@ AWS credential chain.
 gateway:
   host: "0.0.0.0"
   port: 50051
+  streaming_max_workers: 100
+  request_queue_maxsize: 100
+  response_queue_maxsize: 100
+  max_terminal_playback_seconds: 30
 ```
 
 `host` and `port` control the insecure application listener. Production deployments should
 place it behind an approved TLS boundary or add an appropriate secure listener. See
 [Security Configuration](../docs/Security-Configuration.md).
 
-The gRPC worker count, maximum message sizes, and concurrent-stream option are currently set
-in `main.py`; values elsewhere in YAML are not production capacity controls.
+`streaming_max_workers` sizes the method-specific executor for long-lived caller streams.
+`request_queue_maxsize` and `response_queue_maxsize` bound the number of protobuf messages
+buffered per stream while caller ingestion, ordered connector processing, and WxCC response
+delivery run independently. Both queue sizes must be greater than zero. The queues bound
+memory and apply backpressure; they are not production throughput targets.
+
+`max_terminal_playback_seconds` is a safety ceiling for the buffered-WAV announcement gate.
+Maximum gRPC message sizes and the concurrent-stream option remain set in `main.py`.
 
 ## Voice Activity Detection
 

--- a/config/config.cloudrun.yaml
+++ b/config/config.cloudrun.yaml
@@ -16,6 +16,8 @@
 gateway:
   host: "0.0.0.0"
   port: 50051
+  request_queue_maxsize: 100
+  response_queue_maxsize: 100
 
 # Gateway-owned speech boundaries sent to Webex Contact Center. GECX still
 # receives each caller-audio frame immediately through BidiRunSession.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,6 +7,10 @@ gateway:
   # Long-lived caller streams use a dedicated executor so they cannot starve
   # health and unary RPCs on the shared gRPC worker pool.
   streaming_max_workers: 100
+  # Bound per-stream buffering while request ingestion, connector processing,
+  # and response delivery run independently.
+  request_queue_maxsize: 100
+  response_queue_maxsize: 100
   # Safety ceiling only; the actual terminal gate is derived from each CES WAV.
   max_terminal_playback_seconds: 30
 

--- a/main.py
+++ b/main.py
@@ -321,6 +321,12 @@ def main():
             max_terminal_playback_seconds=float(
                 gateway_config.get("max_terminal_playback_seconds", 30.0)
             ),
+            request_queue_maxsize=int(
+                gateway_config.get("request_queue_maxsize", 100)
+            ),
+            response_queue_maxsize=int(
+                gateway_config.get("response_queue_maxsize", 100)
+            ),
         )
         logger.info("WxCCGatewayServer created")
 

--- a/src/core/wxcc_gateway_server.py
+++ b/src/core/wxcc_gateway_server.py
@@ -31,14 +31,14 @@ from src.generated.voicevirtualagent_pb2 import (
     VoiceVAResponse,
 )
 from src.generated.voicevirtualagent_pb2_grpc import VoiceVirtualAgentServicer
-
-from .virtual_agent_router import VirtualAgentRouter
-from .health_service import HealthCheckService
 from src.utils.audio_normalizer import normalize_wxcc_audio
 from src.utils.silero_speech_boundary import (
     SileroSpeechBoundaryObserver,
     SpeechBoundarySignal,
 )
+
+from .health_service import HealthCheckService
+from .virtual_agent_router import VirtualAgentRouter
 
 
 class ConversationProcessor:
@@ -114,7 +114,16 @@ class ConversationProcessor:
         self, response_sink: Callable[[VoiceVAResponse], bool]
     ) -> None:
         """Attach the bounded stream queue used by asynchronous boundary work."""
-        self._async_response_sink = response_sink
+        with self._speech_end_lock:
+            self._async_response_sink = response_sink
+
+    def clear_async_response_sink(
+        self, response_sink: Callable[[VoiceVAResponse], bool]
+    ) -> None:
+        """Detach one completed stream without clearing a newer reconnect."""
+        with self._speech_end_lock:
+            if self._async_response_sink is response_sink:
+                self._async_response_sink = None
 
     def has_async_work(self) -> bool:
         """Return whether a delayed speech boundary is still being processed."""
@@ -1221,6 +1230,8 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
         router: VirtualAgentRouter,
         vad_config: Optional[Dict[str, Any]] = None,
         max_terminal_playback_seconds: float = 30.0,
+        request_queue_maxsize: int = 100,
+        response_queue_maxsize: int = 100,
     ) -> None:
         """
         Initialize the WxCC Gateway Server.
@@ -1228,10 +1239,18 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
         Args:
             router: VirtualAgentRouter instance for routing requests to connectors
             vad_config: Gateway-owned voice activity detection settings.
+            request_queue_maxsize: Maximum caller requests buffered per stream.
+            response_queue_maxsize: Maximum gateway responses buffered per stream.
         """
         self.router = router
         self.vad_config = vad_config or {}
         self.max_terminal_playback_seconds = max_terminal_playback_seconds
+        self.request_queue_maxsize = self._positive_queue_size(
+            request_queue_maxsize, "request_queue_maxsize"
+        )
+        self.response_queue_maxsize = self._positive_queue_size(
+            response_queue_maxsize, "response_queue_maxsize"
+        )
         self.logger = logging.getLogger(__name__)
 
         # Conversation state management - track active conversations by conversation_id
@@ -1244,6 +1263,14 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
         self.health_service = HealthCheckService(self.router)
 
         self.logger.info("WxCCGatewayServer initialized")
+
+    @staticmethod
+    def _positive_queue_size(value: int, name: str) -> int:
+        """Return a validated bounded stream queue size."""
+        queue_size = int(value)
+        if queue_size <= 0:
+            raise ValueError(f"{name} must be greater than zero")
+        return queue_size
 
     def shutdown(self):
         """Gracefully shut down the server and cleanup conversations."""
@@ -1406,9 +1433,16 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
         agent_id = None
         processor = None
         stream_cancel_event = threading.Event()
-        input_done = threading.Event()
-        response_queue: queue.Queue[VoiceVAResponse] = queue.Queue(maxsize=100)
+        request_reader_done = threading.Event()
+        request_processor_done = threading.Event()
+        request_queue: queue.Queue[VoiceVARequest] = queue.Queue(
+            maxsize=self.request_queue_maxsize
+        )
+        response_queue: queue.Queue[VoiceVAResponse] = queue.Queue(
+            maxsize=self.response_queue_maxsize
+        )
         state = {"stream_end_reason": "client_half_close"}
+        state_lock = threading.Lock()
 
         def wake_stream() -> None:
             stream_cancel_event.set()
@@ -1416,21 +1450,75 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
         if context:
             context.add_callback(wake_stream)
 
-        def enqueue_response(response: VoiceVAResponse) -> bool:
+        def set_stream_end_reason(reason: str) -> None:
+            """Record lifecycle outcomes without losing a terminal decision."""
+            with state_lock:
+                current_reason = state["stream_end_reason"]
+                if current_reason == "server_terminal":
+                    return
+                if (
+                    reason == "server_terminal"
+                    or current_reason == "client_half_close"
+                ):
+                    state["stream_end_reason"] = reason
+
+        def enqueue_request(request: VoiceVARequest) -> bool:
             while not stream_cancel_event.is_set():
                 try:
-                    response_queue.put(response, timeout=0.25)
-                    return True
+                    request_queue.put(request, timeout=0.25)
+                    return not stream_cancel_event.is_set()
                 except queue.Full:
                     continue
             return False
 
-        def consume_requests() -> None:
-            nonlocal conversation_id, agent_id, processor
+        def enqueue_response(response: VoiceVAResponse) -> bool:
+            while not stream_cancel_event.is_set():
+                try:
+                    response_queue.put(response, timeout=0.25)
+                    return not stream_cancel_event.is_set()
+                except queue.Full:
+                    continue
+            return False
+
+        def read_requests() -> None:
+            """Read WxCC input independently of connector response production."""
             try:
                 for request in request_iterator:
+                    if not enqueue_request(request):
+                        return
+            except grpc.RpcError as error:
+                if error.code() == grpc.StatusCode.CANCELLED:
+                    set_stream_end_reason("client_cancelled")
+                else:
+                    set_stream_end_reason("stream_error")
+                    self.logger.error(
+                        "Error reading ProcessCallerInput stream: %s", error
+                    )
+                    context.set_code(grpc.StatusCode.INTERNAL)
+                    context.set_details(f"Stream error: {str(error)}")
+            except Exception as error:
+                set_stream_end_reason("stream_error")
+                self.logger.error(
+                    "Error reading ProcessCallerInput stream: %s", error
+                )
+                context.set_code(grpc.StatusCode.INTERNAL)
+                context.set_details(f"Stream error: {str(error)}")
+            finally:
+                request_reader_done.set()
+
+        def process_requests() -> None:
+            """Process caller requests in order and enqueue outbound responses."""
+            nonlocal conversation_id, agent_id, processor
+            try:
+                while True:
                     if stream_cancel_event.is_set():
                         break
+                    try:
+                        request = request_queue.get(timeout=0.25)
+                    except queue.Empty:
+                        if request_reader_done.is_set():
+                            break
+                        continue
 
                     # Extract conversation and agent information from the first request
                     if conversation_id is None:
@@ -1536,35 +1624,41 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
                         "message", conversation_id, agent_id
                     )
                     if processor.can_be_deleted:
-                        state["stream_end_reason"] = "server_terminal"
+                        set_stream_end_reason("server_terminal")
                         return
 
             except grpc.RpcError as error:
                 if error.code() == grpc.StatusCode.CANCELLED:
-                    state["stream_end_reason"] = "client_cancelled"
+                    set_stream_end_reason("client_cancelled")
                 else:
-                    state["stream_end_reason"] = "stream_error"
+                    set_stream_end_reason("stream_error")
                     self.logger.error(
-                        "Error in ProcessCallerInput stream: %s", error
+                        "Error processing ProcessCallerInput stream: %s", error
                     )
                     context.set_code(grpc.StatusCode.INTERNAL)
                     context.set_details(f"Stream error: {str(error)}")
             except Exception as error:
-                state["stream_end_reason"] = "stream_error"
+                set_stream_end_reason("stream_error")
                 self.logger.error(
-                    "Error in ProcessCallerInput stream: %s", error
+                    "Error processing ProcessCallerInput stream: %s", error
                 )
                 context.set_code(grpc.StatusCode.INTERNAL)
                 context.set_details(f"Stream error: {str(error)}")
             finally:
-                input_done.set()
+                request_processor_done.set()
 
-        input_thread = threading.Thread(
-            target=consume_requests,
-            name="wxcc-ingress",
+        request_processor_thread = threading.Thread(
+            target=process_requests,
+            name="wxcc-request-processor",
             daemon=True,
         )
-        input_thread.start()
+        request_reader_thread = threading.Thread(
+            target=read_requests,
+            name="wxcc-request-reader",
+            daemon=True,
+        )
+        request_processor_thread.start()
+        request_reader_thread.start()
 
         try:
             while True:
@@ -1574,12 +1668,20 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
                     if stream_cancel_event.is_set():
                         break
                     if (
-                        input_done.is_set()
+                        request_processor_done.is_set()
                         and response_queue.empty()
                         and (processor is None or not processor.has_async_work())
                     ):
                         break
                     continue
+
+                if stream_cancel_event.is_set():
+                    self.logger.debug(
+                        "Suppressing queued response after stream cancellation "
+                        "for conversation %s",
+                        conversation_id,
+                    )
+                    break
 
                 yield response
                 terminal_event = any(
@@ -1591,7 +1693,7 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
                     for event in response.output_events
                 )
                 if terminal_event:
-                    state["stream_end_reason"] = "server_terminal"
+                    set_stream_end_reason("server_terminal")
                     self.logger.info(
                         "Completing WxCC response stream after terminal response "
                         "for conversation %s",
@@ -1601,9 +1703,20 @@ class WxCCGatewayServer(VoiceVirtualAgentServicer):
                     break
         finally:
             stream_cancel_event.set()
-            input_thread.join(timeout=2.0)
+            request_reader_thread.join(timeout=2.0)
+            request_processor_thread.join(timeout=2.0)
+            for thread in (request_reader_thread, request_processor_thread):
+                if thread.is_alive():
+                    self.logger.error(
+                        "wxcc_stream_thread_join_timeout conversation_id=%s "
+                        "thread=%s",
+                        conversation_id,
+                        thread.name,
+                    )
+            if processor is not None:
+                processor.clear_async_response_sink(enqueue_response)
             if context and not context.is_active():
-                state["stream_end_reason"] = "client_cancelled"
+                set_stream_end_reason("client_cancelled")
 
             # WxCC normally half-closes one request RPC and reconnects with the
             # same conversation ID for subsequent caller input. Preserve the

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -1414,6 +1414,19 @@ class TestClientStreamEndCleanup:
             ),
         )
 
+    @staticmethod
+    def _audio_request(audio_data: bytes) -> VoiceVARequest:
+        return VoiceVARequest(
+            conversation_id="stream-end-conv",
+            virtual_agent_id="GECX Agent",
+            audio_input=VoiceInput(
+                caller_audio=audio_data,
+                encoding=VoiceInput.VoiceEncoding.MULAW_FORMAT,
+                sample_rate_hertz=8000,
+                language_code="en-US",
+            ),
+        )
+
     @pytest.mark.parametrize(
         ("message_type", "expected_event_type"),
         [("session_end", 1), ("transfer", 2)],
@@ -1513,13 +1526,15 @@ class TestClientStreamEndCleanup:
         assert consumed_second_request.wait(1.0)
         assert list(responses) == []
 
-    def test_ingress_continues_while_connector_response_is_still_producing(
+    def test_audio_ingress_is_buffered_while_connector_response_is_producing(
         self
     ):
         router = MagicMock(spec=VirtualAgentRouter)
         allow_response_completion = threading.Event()
-        consumed_second_request = threading.Event()
-        processed_second_request = threading.Event()
+        consumed_audio_requests = threading.Event()
+        processed_audio_requests = threading.Event()
+        processed_audio: list[bytes] = []
+        caller_frames = [b"caller-frame-1", b"caller-frame-2", b"caller-frame-3"]
 
         def start_responses():
             yield self._session_start_response()
@@ -1533,11 +1548,14 @@ class TestClientStreamEndCleanup:
             if operation == "start_conversation":
                 return start_responses()
             if operation == "send_message":
-                processed_second_request.set()
+                processed_audio.append(message_data["audio_data"])
+                if len(processed_audio) == len(caller_frames):
+                    processed_audio_requests.set()
                 return None
             raise AssertionError(f"Unexpected operation: {operation}")
 
         router.route_request.side_effect = route_request
+        router.should_observe_speech_boundaries.return_value = False
         router.should_cleanup_on_client_stream_end.return_value = True
         context = MagicMock()
         context.is_active.return_value = True
@@ -1545,16 +1563,17 @@ class TestClientStreamEndCleanup:
 
         def requests():
             yield self._session_start_request()
-            consumed_second_request.set()
-            yield self._custom_event_request()
+            for caller_frame in caller_frames:
+                yield self._audio_request(caller_frame)
+            consumed_audio_requests.set()
 
         responses = server.ProcessCallerInput(requests(), context)
         first_response = next(responses)
 
         try:
             assert first_response.prompts[0].text == "Connected"
-            assert consumed_second_request.wait(0.5)
-            assert processed_second_request.is_set() is False
+            assert consumed_audio_requests.wait(0.5)
+            assert processed_audio == []
         finally:
             allow_response_completion.set()
 
@@ -1563,7 +1582,8 @@ class TestClientStreamEndCleanup:
         assert [response.prompts[0].text for response in remaining_responses] == [
             "The first response is complete."
         ]
-        assert processed_second_request.is_set()
+        assert processed_audio_requests.is_set()
+        assert processed_audio == caller_frames
 
     def test_bounded_ingress_backpressure_stops_on_stream_cancellation(self):
         router = MagicMock(spec=VirtualAgentRouter)

--- a/tests/test_wxcc_gateway_server.py
+++ b/tests/test_wxcc_gateway_server.py
@@ -1440,19 +1440,18 @@ class TestClientStreamEndCleanup:
         context = MagicMock()
         context.is_active.return_value = True
         server = WxCCGatewayServer(router)
-        consumed_second_request = False
 
         def requests():
-            nonlocal consumed_second_request
             yield self._session_start_request()
-            consumed_second_request = True
             yield self._custom_event_request()
 
         responses = list(server.ProcessCallerInput(requests(), context))
 
         assert len(responses) == 1
         assert responses[0].output_events[0].event_type == expected_event_type
-        assert consumed_second_request is False
+        assert [
+            call.args[1] for call in router.route_request.call_args_list
+        ] == ["start_conversation", "end_conversation"]
         assert "stream-end-conv" not in server.conversations
         router.route_request.assert_any_call(
             "GECX Agent",
@@ -1514,6 +1513,173 @@ class TestClientStreamEndCleanup:
         assert consumed_second_request.wait(1.0)
         assert list(responses) == []
 
+    def test_ingress_continues_while_connector_response_is_still_producing(
+        self
+    ):
+        router = MagicMock(spec=VirtualAgentRouter)
+        allow_response_completion = threading.Event()
+        consumed_second_request = threading.Event()
+        processed_second_request = threading.Event()
+
+        def start_responses():
+            yield self._session_start_response()
+            assert allow_response_completion.wait(1.0)
+            yield {
+                **self._session_start_response(),
+                "text": "The first response is complete.",
+            }
+
+        def route_request(agent_id, operation, conversation_id, message_data):
+            if operation == "start_conversation":
+                return start_responses()
+            if operation == "send_message":
+                processed_second_request.set()
+                return None
+            raise AssertionError(f"Unexpected operation: {operation}")
+
+        router.route_request.side_effect = route_request
+        router.should_cleanup_on_client_stream_end.return_value = True
+        context = MagicMock()
+        context.is_active.return_value = True
+        server = WxCCGatewayServer(router)
+
+        def requests():
+            yield self._session_start_request()
+            consumed_second_request.set()
+            yield self._custom_event_request()
+
+        responses = server.ProcessCallerInput(requests(), context)
+        first_response = next(responses)
+
+        try:
+            assert first_response.prompts[0].text == "Connected"
+            assert consumed_second_request.wait(0.5)
+            assert processed_second_request.is_set() is False
+        finally:
+            allow_response_completion.set()
+
+        remaining_responses = list(responses)
+
+        assert [response.prompts[0].text for response in remaining_responses] == [
+            "The first response is complete."
+        ]
+        assert processed_second_request.is_set()
+
+    def test_bounded_ingress_backpressure_stops_on_stream_cancellation(self):
+        router = MagicMock(spec=VirtualAgentRouter)
+        allow_response_completion = threading.Event()
+        requested_second_buffered_input = threading.Event()
+        requested_third_buffered_input = threading.Event()
+        existing_thread_ids = {id(thread) for thread in threading.enumerate()}
+
+        def start_responses():
+            yield self._session_start_response()
+            assert allow_response_completion.wait(1.0)
+
+        router.route_request.side_effect = (
+            lambda agent_id, operation, conversation_id, message_data: (
+                start_responses() if operation == "start_conversation" else None
+            )
+        )
+        router.should_cleanup_on_client_stream_end.return_value = True
+        context = MagicMock()
+        context.is_active.return_value = False
+        server = WxCCGatewayServer(router, request_queue_maxsize=1)
+
+        def requests():
+            yield self._session_start_request()
+            yield self._custom_event_request()
+            requested_second_buffered_input.set()
+            yield self._custom_event_request()
+            requested_third_buffered_input.set()
+            yield self._custom_event_request()
+
+        responses = server.ProcessCallerInput(requests(), context)
+        first_response = next(responses)
+
+        assert first_response.prompts[0].text == "Connected"
+        assert requested_second_buffered_input.wait(0.5)
+        assert requested_third_buffered_input.is_set() is False
+
+        cancel_stream = context.add_callback.call_args.args[0]
+        cancel_stream()
+        allow_response_completion.set()
+
+        assert list(responses) == []
+        assert requested_third_buffered_input.is_set() is False
+        assert [
+            thread
+            for thread in threading.enumerate()
+            if id(thread) not in existing_thread_ids
+            and thread.name
+            in {"wxcc-request-reader", "wxcc-request-processor"}
+        ] == []
+
+    def test_bounded_response_backpressure_stops_on_stream_cancellation(self):
+        router = MagicMock(spec=VirtualAgentRouter)
+        attempted_third_response = threading.Event()
+        completed_response_iterator = threading.Event()
+        existing_thread_ids = {id(thread) for thread in threading.enumerate()}
+
+        def start_responses():
+            yield self._session_start_response()
+            yield {
+                **self._session_start_response(),
+                "text": "Second buffered response",
+            }
+            attempted_third_response.set()
+            yield {
+                **self._session_start_response(),
+                "text": "Third buffered response",
+            }
+            completed_response_iterator.set()
+
+        router.route_request.side_effect = (
+            lambda agent_id, operation, conversation_id, message_data: (
+                start_responses() if operation == "start_conversation" else None
+            )
+        )
+        router.should_cleanup_on_client_stream_end.return_value = True
+        context = MagicMock()
+        context.is_active.return_value = False
+        server = WxCCGatewayServer(router, response_queue_maxsize=1)
+
+        responses = server.ProcessCallerInput(
+            iter([self._session_start_request()]), context
+        )
+        first_response = next(responses)
+
+        assert first_response.prompts[0].text == "Connected"
+        assert attempted_third_response.wait(0.5)
+        assert completed_response_iterator.is_set() is False
+
+        cancel_stream = context.add_callback.call_args.args[0]
+        cancel_stream()
+
+        assert list(responses) == []
+        assert completed_response_iterator.is_set() is False
+        assert [
+            thread
+            for thread in threading.enumerate()
+            if id(thread) not in existing_thread_ids
+            and thread.name
+            in {"wxcc-request-reader", "wxcc-request-processor"}
+        ] == []
+
+    @pytest.mark.parametrize(
+        ("argument", "message"),
+        [
+            ({"request_queue_maxsize": 0}, "request_queue_maxsize"),
+            ({"response_queue_maxsize": 0}, "response_queue_maxsize"),
+        ],
+    )
+    def test_stream_queue_sizes_must_be_positive(self, argument, message):
+        with pytest.raises(ValueError, match=message):
+            WxCCGatewayServer(
+                MagicMock(spec=VirtualAgentRouter),
+                **argument,
+            )
+
     def test_opted_in_connector_survives_half_close_and_reconnection(self):
         router = MagicMock(spec=VirtualAgentRouter)
         router.route_request.side_effect = [self._session_start_response(), None]
@@ -1532,6 +1698,10 @@ class TestClientStreamEndCleanup:
         assert len(first_responses) == 1
         assert second_responses == []
         assert "stream-end-conv" in server.conversations
+        assert (
+            server.conversations["stream-end-conv"]._async_response_sink
+            is None
+        )
         start_calls = [
             call
             for call in router.route_request.call_args_list

--- a/tools/byova_e2e/README.md
+++ b/tools/byova_e2e/README.md
@@ -307,6 +307,14 @@ byova-e2e run --destination 9999 \
 
 byova-e2e run --destination 9999 \
   --config config/gecx-regression.spec.json \
+  --test multi-turn-response
+
+byova-e2e run --destination 9999 \
+  --config config/gecx-regression.spec.json \
+  --test speak-during-playback
+
+byova-e2e run --destination 9999 \
+  --config config/gecx-regression.spec.json \
   --test task-complete
 
 byova-e2e run --destination 9999 \
@@ -319,6 +327,11 @@ Correlate each artifact window and config SHA-256 with gateway and CES evidence:
 - `normal-response`: one caller turn and no terminal output event.
 - `natural-pause`: one outward `START_OF_INPUT`, one merged resume, one outward
   `END_OF_INPUT`, and one complete CES transcript.
+- `multi-turn-response`: two caller injections, two complete GECX responses,
+  and no terminal output event.
+- `speak-during-playback`: the second caller injection begins after the first
+  GECX response starts, reaches GECX while response audio is active, and
+  produces a later complete response.
 - `task-complete`: one `SESSION_END` output event before the remote disconnect.
 - `transfer`: one `TRANSFER_TO_AGENT` output event and both configured
   post-input announcement epochs.

--- a/tools/byova_e2e/README.md
+++ b/tools/byova_e2e/README.md
@@ -329,9 +329,12 @@ Correlate each artifact window and config SHA-256 with gateway and CES evidence:
   `END_OF_INPUT`, and one complete CES transcript.
 - `multi-turn-response`: two caller injections, two complete GECX responses,
   and no terminal output event.
-- `speak-during-playback`: the second caller injection begins after the first
-  GECX response starts, reaches GECX while response audio is active, and
-  produces a later complete response.
+- `speak-during-playback`: an audio-plane probe in Phase 2. The second caller
+  injection begins after the first GECX response starts and the call remains
+  healthy through remote-audio completion. Buffered GECX prompts keep barge-in
+  disabled until Phase 4, so a green runner result does **not** prove CES
+  received the second utterance; correlate the CES transcript and record that
+  live semantic gap explicitly.
 - `task-complete`: one `SESSION_END` output event before the remote disconnect.
 - `transfer`: one `TRANSFER_TO_AGENT` output event and both configured
   post-input announcement epochs.

--- a/tools/byova_e2e/config/gecx-regression.spec.json
+++ b/tools/byova_e2e/config/gecx-regression.spec.json
@@ -88,8 +88,8 @@
     },
     {
       "id": "speak-during-playback",
-      "title": "accepts a caller turn while GECX audio is playing",
-      "description": "Caller ingress remains active during a GECX response and produces a later complete response.",
+      "title": "probes caller injection while GECX audio is playing",
+      "description": "Audio-plane probe only: the browser injects during playback and verifies the call remains healthy. Because buffered GECX prompts keep barge-in disabled until Phase 4, a green runner result does not prove that CES received the second utterance; correlate the CES transcript.",
       "steps": [
         {
           "name": "Request a detailed hotel description",
@@ -108,7 +108,7 @@
           "text": "Actually, I only need a queen room."
         },
         {
-          "name": "Expect a later complete virtual-agent response",
+          "name": "Observe remote audio completion without a call failure",
           "expect": {
             "outcome": "response",
             "responsePrompts": 1

--- a/tools/byova_e2e/config/gecx-regression.spec.json
+++ b/tools/byova_e2e/config/gecx-regression.spec.json
@@ -56,6 +56,67 @@
       ]
     },
     {
+      "id": "multi-turn-response",
+      "title": "continues a hotel request across two caller turns",
+      "description": "The gateway continues ingesting caller audio after delivering a complete GECX response.",
+      "steps": [
+        {
+          "name": "Start a hotel request",
+          "action": "speak",
+          "text": "I'd like to book a hotel."
+        },
+        {
+          "name": "Expect the first complete virtual-agent response",
+          "expect": {
+            "outcome": "response",
+            "responsePrompts": 1
+          }
+        },
+        {
+          "name": "Continue with a room preference",
+          "action": "speak",
+          "text": "I need a queen room."
+        },
+        {
+          "name": "Expect the second complete virtual-agent response",
+          "expect": {
+            "outcome": "response",
+            "responsePrompts": 1
+          }
+        }
+      ]
+    },
+    {
+      "id": "speak-during-playback",
+      "title": "accepts a caller turn while GECX audio is playing",
+      "description": "Caller ingress remains active during a GECX response and produces a later complete response.",
+      "steps": [
+        {
+          "name": "Request a detailed hotel description",
+          "action": "speak",
+          "text": "Please describe all of the available hotel room types and amenities."
+        },
+        {
+          "name": "Wait only for the virtual-agent response to start",
+          "expect": {
+            "outcome": "response-start"
+          }
+        },
+        {
+          "name": "Speak a new preference during playback",
+          "action": "speak",
+          "text": "Actually, I only need a queen room."
+        },
+        {
+          "name": "Expect a later complete virtual-agent response",
+          "expect": {
+            "outcome": "response",
+            "responsePrompts": 1
+          }
+        }
+      ]
+    },
+    {
       "id": "task-complete",
       "title": "ends a successfully completed task",
       "description": "The virtual agent closes a completed interaction and WxCC disconnects the caller.",


### PR DESCRIPTION
## Summary

- decouple WxCC request ingestion from ordered connector response production and
  response yielding with independently bounded per-stream queues
- make queue backpressure, cancellation, worker shutdown, half-close/reconnect,
  and response-sink detachment deterministic
- preserve the existing buffered final-WAV response path and first-terminal
  decision behavior
- expose and document request/response queue sizes
- add GECX multi-turn and playback-time audio-plane E2E scenarios

This PR intentionally targets `feat/gecx-connector`, not `main`, while the full
SE-1943 feature remains under development.

## Scope boundaries

- GECX audio delivery remains one buffered `FINAL` WAV per completed agent turn.
- BYOVA `CHUNK` output is Phase 3.
- GECX prompt barge-in remains disabled until Phase 4. The
  `speak-during-playback` scenario is therefore explicitly documented as an
  audio-plane probe; a green browser result does not assert CES received the
  second utterance.

## Verification

- 383 repository tests passed
- 104 focused gateway/GECX tests passed
- 53 E2E Python tests passed
- 4 browser tests passed
- TypeScript/Vite production build passed
- six-test GECX plan validated with SHA-256
  `7c148738c37d004a32c86a89d74bc466a1b536b42a057131050aac30beaa4230`
- deterministic concurrency coverage proves three real caller `VoiceInput`
  frames enter the bounded queue while connector output is blocked and later
  reach the connector in their original order with no loss

## Dev evidence

Source commit `032e728` was deployed to the AWS dev gateway. The later
`9ca402c` commit changes tests and operator evidence wording only.

- normal response: passed and correlated to CES conversation
  `922622ffb1344f72892e035675d27998`
- bounded natural pause: passed as one intact CES turn,
  `88f540a581da4bcba404832f09de8d0e`
- multi-turn: passed with two caller and two agent turns,
  `96ab8ec21d584c719cda8eddebc9ad33`
- successful task completion: passed with a remote normal disconnect and
  `sessionContained=true`, `1247b47d2e06444b8d2214b4551266bd`
- transfer: passed with two announcement epochs and
  `sessionEscalated=true`, `20a77a324ae94ccfaacef6163b79d977`
- playback-time probe: browser injection occurred during remote audio, but CES
  correctly contains no second turn while barge-in is disabled,
  `29c6ebee2d5c45d185e72e80c193009f`

AWS ALB logs contain 17 `ProcessCallerInput` RPCs for the six-call window. Every
RPC has both ALB and target status `200`; the gRPC and HTTP targets and public
health endpoint remained healthy afterward.

## Recorded follow-ups

- Add an ordered caller-hangup action to the generic JSON E2E runner before
  automating hangup-during-playback. Normal end-of-test disconnect is not
  equivalent evidence.
- Enable and validate semantic live barge-in in Phase 4.
- CES runtime calls are not present in Cloud Logging; regional Contact Center
  Insights conversations are the authoritative Google-side transcript and
  terminal evidence.
