### PR TITLE
feat: manage BYODS datasource lifecycle

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -80,6 +80,7 @@ webex-byova-gateway-python/
 │   │   ├── i_vendor_connector.py
 │   │   └── local_audio_connector.py
 │   ├── core/                # Core gateway components
+│   │   ├── datasource_lifecycle.py
 │   │   ├── virtual_agent_router.py
 │   │   ├── wxcc_gateway_server.py
 │   │   └── *.py            # Generated gRPC stubs
@@ -137,6 +138,15 @@ webex-byova-gateway-python/
 - Processes different input types (audio, DTMF, events)
 - Converts between gRPC and connector formats
 - Handles error conditions and conversation cleanup
+
+### DataSourceLifecycle (`datasource_lifecycle.py`)
+
+- Uses the `webex-byods-sdk` package rather than implementing BYODS REST calls
+- Discovers or registers the gateway datasource before gRPC starts accepting traffic
+- Reconciles URL, schema, audience, subject, and active status at startup
+- Renews the datasource JWS before `tokenExpiryTime` and retries transient failures
+- Reads credential values only from explicitly named environment variables
+- Requires an explicit datasource ID when discovery returns multiple matches
 
 ## Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The sample includes:
 
 - A BYOVA gRPC server with `ListVirtualAgents` and `ProcessCallerInput`
 - JWT validation for the WxCC data plane
+- Optional BYODS datasource registration and pre-expiry JWS renewal
 - A configuration-driven connector router
 - Local audio and AWS Lex connectors
 - gRPC and HTTP health checks
@@ -53,7 +54,8 @@ Before WxCC can connect to this gateway, you need:
   exchange domain for your gateway
 - Authorization of that Service App by an administrator in the target organization
 - A publicly reachable TLS-enabled gRPC server URL on the authorized domain
-- An `ACTIVE` BYOVA data-source registration whose URL exactly matches the public server URL
+- An `ACTIVE` BYOVA data-source registration whose URL exactly matches the public server URL;
+  the gateway can create and renew this registration when datasource management is enabled
 - A Contact Center AI virtual-agent configuration and a test flow that uses the Virtual
   Agent V2 activity
 - A configured gateway connector: use the local audio connector for a vendor-neutral
@@ -106,6 +108,30 @@ jwt_validation:
 Never use disabled authentication for a Webex-connected or production endpoint. For an
 end-to-end test, configure the exact registered datasource URL and keep JWT enforcement
 enabled.
+
+### Configure Automatic Datasource Management
+
+The optional datasource lifecycle uses
+[`webex-byods-sdk`](https://github.com/WebexCommunity/webex-python-byods-sdk) to discover or
+register this gateway before gRPC starts accepting traffic and to renew its JWS before
+expiry. Configure `jwt_validation.datasource_url`, then enable:
+
+```yaml
+data_source:
+  enabled: true
+  auth:
+    type: "oauth_refresh"
+    client_id_env: "WEBEX_BYODS_CLIENT_ID"
+    client_secret_env: "WEBEX_BYODS_CLIENT_SECRET"
+    refresh_token_env: "WEBEX_BYODS_REFRESH_TOKEN"
+```
+
+Set the named environment variables from an authorized Service App with
+`spark-admin:datasource_read` and `spark-admin:datasource_write`. The gateway discovers an
+exact URL/schema/audience/subject match when no datasource ID is configured, reconciles
+configuration drift, and renews the token 60 minutes before expiry by default. See the
+[Configuration Reference](config/README.md#byods-datasource-lifecycle) for all settings and
+the static-token development option.
 
 ### Run
 
@@ -186,7 +212,7 @@ webex-byova-gateway-python/
 ├── src/
 │   ├── auth/           # gRPC JWT validation
 │   ├── connectors/     # Virtual-agent connectors
-│   ├── core/           # Gateway server, routing, and health
+│   ├── core/           # Datasource lifecycle, gateway server, routing, and health
 │   ├── generated/      # Locally generated gRPC modules
 │   ├── monitoring/     # Development monitoring interface
 │   └── utils/          # Audio utilities

--- a/config/README.md
+++ b/config/README.md
@@ -157,6 +157,44 @@ URL. The gateway will not start with an empty value.
 See [gRPC JWT Authentication](../docs/JWT_AUTHENTICATION.md) for claims, issuers, deployment
 modes, and troubleshooting.
 
+## BYODS Datasource Lifecycle
+
+The optional `data_source` section uses `webex-byods-sdk` to discover or register the
+gateway datasource before the gRPC listener starts and renew its JWS before expiry:
+
+```yaml
+data_source:
+  enabled: true
+  fail_startup_on_error: true
+  id: ""
+  id_env: "WEBEX_BYODS_DATA_SOURCE_ID"
+  # Empty values inherit the JWT validation URL and schema.
+  url: ""
+  schema_id: ""
+  audience: "BYOVAGateway"
+  subject: "callAudioData"
+  token_lifetime_minutes: 1440
+  renewal_lead_time_minutes: 60
+  retry_interval_seconds: 60
+  auth:
+    type: "oauth_refresh"
+    client_id_env: "WEBEX_BYODS_CLIENT_ID"
+    client_secret_env: "WEBEX_BYODS_CLIENT_SECRET"
+    refresh_token_env: "WEBEX_BYODS_REFRESH_TOKEN"
+```
+
+Values ending in `_env` name environment variables; they do not contain credentials. The
+Service App needs `spark-admin:datasource_read` and `spark-admin:datasource_write`.
+
+When neither `id` nor the variable named by `id_env` supplies an ID, startup searches for a
+matching URL, schema, audience, and subject. It registers only when no match exists and
+rejects ambiguous matches. Explicit `url` and `schema_id` values must match the corresponding
+`jwt_validation` settings.
+
+For short-lived development, use `auth.type: "static"` with
+`access_token_env: "WEBEX_BYODS_ACCESS_TOKEN"`. Static access tokens cannot be refreshed;
+use OAuth refresh credentials for unattended operation.
+
 ## Logging
 
 ```yaml
@@ -222,6 +260,7 @@ Common checks:
 
 - [Local development](../docs/LOCAL_DEVELOPMENT.md)
 - [Local audio configuration](../docs/LOCAL_AUDIO_CONFIGURATION.md)
+- [BYODS datasource lifecycle](#byods-datasource-lifecycle)
 - [JWT authentication](../docs/JWT_AUTHENTICATION.md)
 - [Testing](../docs/TESTING.md)
 - [Return to the project README](../README.md)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -109,6 +109,42 @@ jwt_validation:
   # Public keys are fetched from Webex identity broker and cached to improve performance
   cache_duration_minutes: 60
 
+# BYODS datasource registration and token lifecycle
+data_source:
+  # Enable to discover/register this gateway with Webex at startup and renew
+  # its JWS before expiration.
+  enabled: false
+
+  # Stop gateway startup if registration or initial renewal fails.
+  fail_startup_on_error: true
+
+  # Optional existing datasource ID. When empty, the gateway discovers a
+  # matching datasource or registers one. id_env takes precedence when id is empty.
+  id: ""
+  id_env: "WEBEX_BYODS_DATA_SOURCE_ID"
+
+  # Leave URL and schema empty to reuse the JWT validation values above.
+  # If explicitly configured, they must exactly match the JWT values.
+  url: ""
+  schema_id: ""
+  audience: "BYOVAGateway"
+  subject: "callAudioData"
+
+  # Webex supports a maximum JWS lifetime of 1440 minutes (24 hours).
+  token_lifetime_minutes: 1440
+  renewal_lead_time_minutes: 60
+  retry_interval_seconds: 60
+
+  # The SDK reads credential values from these environment variables. An OAuth
+  # refresh token supports unattended access-token renewal. A static access
+  # token can be used for short-lived development by setting type: "static"
+  # and access_token_env: "WEBEX_BYODS_ACCESS_TOKEN".
+  auth:
+    type: "oauth_refresh"
+    client_id_env: "WEBEX_BYODS_CLIENT_ID"
+    client_secret_env: "WEBEX_BYODS_CLIENT_SECRET"
+    refresh_token_env: "WEBEX_BYODS_REFRESH_TOKEN"
+
 # Logging configuration
 logging:
   gateway:

--- a/docs/CUSTOMER_EVALUATION.md
+++ b/docs/CUSTOMER_EVALUATION.md
@@ -67,15 +67,24 @@ a derivative of this sample.
 3. Decide who will own the Service App, public gateway endpoint, and voice-agent connector.
 4. Create and authorize the Service App, including the Voice Virtual Agent schema and the
    gateway's data exchange domain.
-5. Make the gateway available at a public TLS-enabled server URL, then register an `ACTIVE`
-   BYOVA data source using that exact URL. Use the same value for
-   `jwt_validation.datasource_url` in the gateway configuration.
+5. Make the gateway available at a public TLS-enabled server URL and set that exact value in
+   `jwt_validation.datasource_url`. Enable automatic datasource lifecycle management to
+   discover or register the `ACTIVE` BYOVA datasource and renew its JWS, or register and
+   maintain it manually.
 6. Configure Contact Center AI and add the Virtual Agent V2 activity to a test flow.
 
 Use the current [Service App authorization steps](https://help.webex.com/default/article/5g8s6u),
 [BYODS guide](https://developer.webex.com/webex-contact-center/docs/bring-your-own-data-source-cc),
 and [BYOVA developer guide](https://developer.webex.com/webex-contact-center/docs/bring-your-own-virtual-agent)
 for the Webex onboarding flow.
+
+For the automatic path, provide the authorized Service App OAuth credentials through
+environment variables and set `data_source.enabled: true`. The gateway establishes the
+datasource before accepting gRPC traffic and prints the ID needed by the Contact Center
+virtual-agent feature. Follow
+[Local Audio Connector Configuration](LOCAL_AUDIO_CONFIGURATION.md#3-enable-automatic-byova-data-source-registration)
+for a complete sandbox example and
+[Configuration](../config/README.md#byods-datasource-lifecycle) for all lifecycle settings.
 
 For a complete first-time walkthrough, including these dependencies in the required order,
 follow the

--- a/docs/JWT_AUTHENTICATION.md
+++ b/docs/JWT_AUTHENTICATION.md
@@ -56,6 +56,39 @@ https://gateway.example.com:443
 Copy the registered value rather than reconstructing it. Use the same URL when a temporary
 development endpoint changes.
 
+### Automatic Registration and JWT Claim Alignment
+
+The optional `data_source` lifecycle can discover or register the datasource before the
+gRPC listener starts and renew its JWS before expiry. Leave its URL and schema empty to
+inherit the JWT values:
+
+```yaml
+jwt_validation:
+  enabled: true
+  enforce_validation: true
+  datasource_url: "https://your-gateway.example.com:443"
+  datasource_schema_uuid: "5397013b-7920-4ffc-807c-e8a3e0a18f43"
+
+data_source:
+  enabled: true
+  fail_startup_on_error: true
+  url: ""
+  schema_id: ""
+  auth:
+    type: "oauth_refresh"
+    client_id_env: "WEBEX_BYODS_CLIENT_ID"
+    client_secret_env: "WEBEX_BYODS_CLIENT_SECRET"
+    refresh_token_env: "WEBEX_BYODS_REFRESH_TOKEN"
+```
+
+Set the named environment variables from an authorized Service App. With empty lifecycle
+URL and schema values, registration and validation share one source of truth. If both
+sections explicitly configure either value, startup rejects a mismatch.
+
+The datasource token managed by this lifecycle is separate from each inbound request JWT:
+the lifecycle creates and renews the registration's JWS, while the interceptor validates
+the signed JWT Webex sends with a gRPC request.
+
 ### Datasource Schema UUID
 
 The standard Voice Virtual Agent schema UUID used by this sample is:
@@ -153,7 +186,8 @@ before making a key request to prevent arbitrary key-fetch URLs.
 
 ### Datasource Claims Validation Failed
 
-- Copy the exact registered datasource URL into the configuration.
+- Copy the exact registered datasource URL into the configuration, or enable automatic
+  lifecycle management so registration inherits the JWT URL and schema.
 - Check whether the registered URL includes `:443` or a trailing path.
 - Confirm the token schema UUID matches the configured Voice Virtual Agent schema.
 

--- a/docs/LOCAL_AUDIO_CONFIGURATION.md
+++ b/docs/LOCAL_AUDIO_CONFIGURATION.md
@@ -41,7 +41,8 @@ For an end-to-end sandbox call, you also need:
 - A Webex Contact Center sandbox or organization with BYOVA enabled
 - Contact Center administrator access
 - A Webex Service App authorized by the sandbox organization
-- A BYODS data-source registration using the BYOVA schema
+- Service App credentials with `spark-admin:datasource_read` and
+  `spark-admin:datasource_write` when using automatic datasource registration
 - A publicly reachable HTTPS endpoint that supports HTTP/2 gRPC and routes to
   gateway port `50051`
 - A test entry point and a published flow containing a Virtual Agent V2 activity
@@ -207,21 +208,70 @@ The `datasource_url` must exactly match the URL used in the BYODS registration,
 including scheme, hostname, path, and any explicitly supplied port. Restart the
 gateway after changing it.
 
-### 3. Register the BYOVA data source
+### 3. Enable automatic BYOVA data-source registration
 
 Follow the Webex
 [Bring Your Own Virtual Agent](https://developer.webex.com/webex-contact-center/docs/bring-your-own-virtual-agent)
 and
 [Bring Your Own Data Source](https://developer.webex.com/webex-contact-center/docs/bring-your-own-data-source-cc)
-guides to:
+guides to confirm BYOVA is enabled, create a Service App with the required
+data-source scopes and allowed gateway domain, and have a sandbox administrator
+authorize it.
 
-1. Confirm BYOVA is enabled for the sandbox organization.
-2. Create a Service App with the required data-source scopes and add the gateway
-   hostname as an allowed domain.
-3. Have a sandbox administrator authorize the Service App.
-4. Register a data source with the BYOVA schema UUID
-   `5397013b-7920-4ffc-807c-e8a3e0a18f43` and the exact URL configured above.
-5. Save the returned data-source ID.
+Provide the authorized OAuth credentials through environment variables:
+
+```bash
+export WEBEX_BYODS_CLIENT_ID="your-client-id"
+export WEBEX_BYODS_CLIENT_SECRET="your-client-secret"
+export WEBEX_BYODS_REFRESH_TOKEN="your-refresh-token"
+```
+
+Do not commit these values. Use your deployment platform's secret manager for
+shared or long-running environments.
+
+Enable lifecycle management in `config/config.yaml`:
+
+```yaml
+data_source:
+  enabled: true
+  fail_startup_on_error: true
+  id: ""
+  id_env: "WEBEX_BYODS_DATA_SOURCE_ID"
+  # Empty values inherit jwt_validation.datasource_url and schema.
+  url: ""
+  schema_id: ""
+  audience: "BYOVAGateway"
+  subject: "callAudioData"
+  token_lifetime_minutes: 1440
+  renewal_lead_time_minutes: 60
+  retry_interval_seconds: 60
+  auth:
+    type: "oauth_refresh"
+    client_id_env: "WEBEX_BYODS_CLIENT_ID"
+    client_secret_env: "WEBEX_BYODS_CLIENT_SECRET"
+    refresh_token_env: "WEBEX_BYODS_REFRESH_TOKEN"
+```
+
+Start the gateway after the public endpoint is available. Before accepting gRPC
+traffic, it searches for an exact URL, schema, audience, and subject match. It
+reuses and reconciles one match or registers a new datasource when no match
+exists. The startup summary prints the datasource ID and JWS expiry:
+
+```text
+BYODS Datasource:
+   • Management: ENABLED
+   • ID: <data-source-id>
+   • Token Expires: <timestamp>
+```
+
+Keep the gateway running. It renews the JWS 60 minutes before expiry by default
+and retries a failed renewal every 60 seconds. If more than one existing
+datasource matches, set `WEBEX_BYODS_DATA_SOURCE_ID` to the intended ID and
+restart.
+
+For a one-time manual registration instead, leave `data_source.enabled` set to
+`false`, register the same URL and BYOVA schema through the Webex API, and save
+the returned datasource ID. Automatic renewal is disabled in that mode.
 
 No vendor credentials are needed for the local connector.
 
@@ -231,7 +281,7 @@ In Control Hub:
 
 1. Go to **Contact Center > Integrations > Features**.
 2. Create a virtual-agent feature using the authorized Service App.
-3. Use the data-source ID as the resource identifier.
+3. Use the datasource ID printed by gateway startup as the resource identifier.
 4. Give it a recognizable name such as `BYOVA Local Audio Test`.
 
 ### 5. Configure and publish the flow
@@ -296,6 +346,17 @@ when the diagnostic is complete.
 JWT validation is enabled without a URL. For a localhost-only smoke test, set
 `jwt_validation.enabled` to `false`. For a sandbox call, configure the exact
 public BYODS URL and leave validation enabled.
+
+### Automatic datasource registration fails during startup
+
+- Confirm the three `WEBEX_BYODS_*` environment variables are available to the
+  gateway process.
+- Confirm the authorized Service App has both datasource read and write scopes.
+- Confirm the public URL uses a domain allowed by the Service App.
+- If the logs report multiple matches, set `WEBEX_BYODS_DATA_SOURCE_ID` to the
+  intended datasource ID.
+- Keep `fail_startup_on_error: true` for end-to-end testing so the gateway does
+  not accept traffic without a managed datasource.
 
 ### The local agent does not appear in Flow Designer
 

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -12,8 +12,9 @@ Always use a virtual environment for this project.
 
 These local prerequisites are sufficient only for running the code and its local connector.
 An end-to-end WxCC test also requires a BYOVA-enabled organization, an authorized Service
-App, a public TLS-enabled gateway URL, an `ACTIVE` data-source registration for that exact
-URL, a configured gateway connector, and a Contact Center flow using Virtual Agent V2.
+App, a public TLS-enabled gateway URL, an `ACTIVE` datasource for that exact URL, a
+configured gateway connector, and a Contact Center flow using Virtual Agent V2. The gateway
+can register and maintain the datasource automatically when lifecycle management is enabled.
 Use the [Local Audio Connector Configuration](LOCAL_AUDIO_CONFIGURATION.md) guide for a
 vendor-neutral sandbox validation. For a complete AWS Lex integration, follow the
 [BYOVA with AWS Lex guide](https://developer.webex.com/webex-contact-center/docs/byova-and-aws-lex)
@@ -124,15 +125,47 @@ App. Use company-owned cloud infrastructure for production and whenever company 
 security review, or compliance is required.
 
 For temporary development testing, a tunneling service may be usable if your organization
-permits it. For example, with ngrok:
+permits it. Start the tunnel first so its public URL is known before gateway startup. For
+example, with ngrok:
 
 ```bash
 ngrok config add-authtoken YOUR_AUTHTOKEN
 ngrok http --upstream-protocol=http2 50051
 ```
 
-Use the generated HTTPS URL consistently in both the data-source registration and
-`jwt_validation.datasource_url`. Free tunnel URLs may change between runs.
+Put the generated HTTPS URL in `jwt_validation.datasource_url`. Free tunnel URLs may change
+between runs.
+
+To let the gateway create or reuse the matching datasource, provide the authorized Service
+App OAuth values and enable lifecycle management:
+
+```bash
+export WEBEX_BYODS_CLIENT_ID="your-client-id"
+export WEBEX_BYODS_CLIENT_SECRET="your-client-secret"
+export WEBEX_BYODS_REFRESH_TOKEN="your-refresh-token"
+```
+
+```yaml
+jwt_validation:
+  enabled: true
+  enforce_validation: true
+  datasource_url: "https://your-current-tunnel.example"
+  datasource_schema_uuid: "5397013b-7920-4ffc-807c-e8a3e0a18f43"
+
+data_source:
+  enabled: true
+  fail_startup_on_error: true
+  auth:
+    type: "oauth_refresh"
+    client_id_env: "WEBEX_BYODS_CLIENT_ID"
+    client_secret_env: "WEBEX_BYODS_CLIENT_SECRET"
+    refresh_token_env: "WEBEX_BYODS_REFRESH_TOKEN"
+```
+
+Start the gateway after saving the URL. Startup completes registration before the gRPC
+listener accepts traffic and prints the datasource ID to use in the Contact Center
+virtual-agent feature. If the tunnel URL changes, update `datasource_url` before restarting;
+the old registration is not deleted automatically.
 
 Consumer tunnels are development-only:
 
@@ -151,6 +184,14 @@ load-balancer starting point.
 If JWT validation is enabled, `jwt_validation.datasource_url` is required. For local-only
 testing, disable JWT validation. For Webex-connected testing, configure the exact registered
 URL. See [JWT Authentication](JWT_AUTHENTICATION.md).
+
+### Datasource Registration Fails
+
+Confirm the Service App is authorized with datasource read and write scopes, the three
+`WEBEX_BYODS_*` environment variables are visible to the gateway process, and the public
+domain is allowed by the Service App. If multiple registrations match the URL and schema,
+set `WEBEX_BYODS_DATA_SOURCE_ID` to the intended datasource ID. See
+[Configuration](../config/README.md#byods-datasource-lifecycle) for all lifecycle options.
 
 ### Port 50051 or 8080 Is Already in Use
 

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -33,6 +33,8 @@ The production service should provide all of the following:
   owned runbooks.
 - Explicit timeouts, bounded retries, backpressure, circuit breakers, and graceful draining.
 - Enforced authentication, encrypted transport, least-privilege access, and managed secrets.
+- An owned BYODS registration lifecycle with monitored renewal and an unambiguous
+  production datasource ID.
 - Privacy controls for caller data, transcripts, DTMF, tokens, and recorded audio.
 - Automated builds, security scanning, staged releases, rollback, and disaster recovery.
 - A staffed service ownership model with incident response and change-management processes.
@@ -359,6 +361,29 @@ use readiness, while operators and dashboards should see dependency detail separ
 
 Use [Security Configuration](Security-Configuration.md) as a starting point, then complete a
 formal threat model and security review.
+
+### BYODS datasource lifecycle
+
+If automatic datasource management is enabled in production:
+
+- Store the Service App client secret and refresh token in a managed secret service and
+  expose them only to the lifecycle owner.
+- Configure `fail_startup_on_error: true` so a new instance does not accept calls when it
+  cannot establish the intended registration.
+- Pin `data_source.id` or `WEBEX_BYODS_DATA_SOURCE_ID` after provisioning rather than relying
+  on discovery in an environment where multiple registrations may share a URL and schema.
+- Decide whether one elected control-plane worker owns renewal or prove that concurrent
+  renewal from multiple replicas is safe for the deployed SDK and Webex API behavior.
+- Monitor successful registration, reconciliation, token expiry, renewal attempts, and
+  repeated renewal failures. Alert before the remaining token lifetime can be exhausted.
+- Test Service App credential rotation, refresh-token revocation, Webex API outages, and
+  process restarts without disrupting active calls.
+- Define how stale registrations are reviewed and retired. The sample does not delete
+  registrations when a hostname or environment is decommissioned.
+
+The sample lifecycle runs in the gateway process and retries failed renewals, but it does
+not provide leader election, durable lifecycle state, production metrics, or alert routing.
+Treat those as productization work rather than assuming process startup is sufficient.
 
 ### Data plane
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ code, not a managed connector or a production-ready service.
 
 ## Authenticate and Secure
 
+- [BYODS Datasource Lifecycle](../config/README.md#byods-datasource-lifecycle): Discover or
+  register the gateway datasource at startup and renew its JWS before expiry.
 - [gRPC JWT Authentication](JWT_AUTHENTICATION.md): Runtime Webex token validation,
   datasource claims, deployment modes, and troubleshooting.
 - [Monitoring Authentication Quick Start](../AUTHENTICATION_QUICKSTART.md): Configure Webex

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ A fully functional voice AI system where customers can:
 ## 🔧 Key Features
 
 - **gRPC Integration**: Seamless communication with Webex Contact Center
+- **Automatic BYODS Lifecycle**: Optional startup registration and pre-expiry JWS renewal
 - **Modular Architecture**: Easy to extend with new virtual agent providers
 - **Real-time Monitoring**: Web dashboard for debugging and monitoring
 - **Multiple Connectors**: Support for local audio testing and AWS Lex integration

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from auth.jwt_interceptor import JWTAuthInterceptor
 
 # Import JWT authentication components (required)
 from auth.jwt_validator import JWTValidator
+from core.datasource_lifecycle import create_data_source_lifecycle
 from core.health_service import HealthCheckService
 from core.virtual_agent_router import VirtualAgentRouter
 from core.wxcc_gateway_server import WxCCGatewayServer
@@ -278,6 +279,8 @@ def main():
     """
     logger = None
     server = None
+    grpc_server = None
+    data_source_lifecycle = None
     try:
         # Load configuration
         config_path = "config/config.yaml"
@@ -317,6 +320,21 @@ def main():
         interceptors = []
         if jwt_interceptor:
             interceptors.append(jwt_interceptor)
+
+        # Establish the BYODS registration before accepting gRPC traffic.
+        data_source_lifecycle = create_data_source_lifecycle(config, logger)
+        if data_source_lifecycle:
+            try:
+                data_source_lifecycle.start()
+            except Exception:
+                if config.get("data_source", {}).get("fail_startup_on_error", True):
+                    raise
+                logger.exception(
+                    "BYODS data source lifecycle failed to start; "
+                    "continuing because fail_startup_on_error is false"
+                )
+                data_source_lifecycle.stop()
+                data_source_lifecycle = None
 
         # Create gRPC server with interceptors
         if interceptors:
@@ -424,6 +442,19 @@ def main():
             print("   • Status: DISABLED")
 
         print()
+        print("🗂️  BYODS Datasource:")
+        if data_source_lifecycle:
+            current_data_source = data_source_lifecycle.current_data_source or {}
+            print("   • Management: ENABLED")
+            print(f"   • ID: {data_source_lifecycle.data_source_id}")
+            print(
+                "   • Token Expires: "
+                f"{current_data_source.get('tokenExpiryTime', 'Not provided')}"
+            )
+        else:
+            print("   • Management: DISABLED")
+
+        print()
         print("✅ Gateway is running! Press Ctrl+C to stop.")
         print("=" * 60)
 
@@ -438,9 +469,17 @@ def main():
             if server:
                 server.shutdown()
             grpc_server.stop(grace=5)
+            if data_source_lifecycle:
+                data_source_lifecycle.stop()
             logger.info("Gateway shutdown complete")
 
     except Exception as e:
+        if grpc_server:
+            grpc_server.stop(grace=0)
+        if server:
+            server.shutdown()
+        if data_source_lifecycle:
+            data_source_lifecycle.stop()
         if logger:
             logger.error(f"Failed to start gateway: {e}")
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "grpcio-tools>=1.50.0",
     "Flask>=2.3.0",
     "PyYAML>=6.0.0",
+    "webex-byods-sdk==0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ blinker>=1.9.0
 PyJWT[crypto]>=2.8.0  # JWT with cryptography support for RSA signature verification
 cryptography>=43.0.0  # Cryptographic operations for JWT validation
 requests>=2.31.0
+webex-byods-sdk==0.2.0
 
 # Audio processing
 pydub>=0.25.1

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -4,6 +4,16 @@ This directory contains the core logic for the Webex Contact Center BYOVA Gatewa
 
 ## Components
 
+### BYODS Datasource Lifecycle (`datasource_lifecycle.py`)
+
+The optional datasource lifecycle is responsible for:
+
+- **Startup Registration**: Discovers or registers the configured gateway URL before gRPC traffic is accepted
+- **Configuration Reconciliation**: Keeps URL, schema, audience, subject, and active status aligned
+- **JWS Renewal**: Uses `webex-byods-sdk` to renew the datasource token before `tokenExpiryTime`
+- **Retry and Shutdown**: Retries background renewal failures and stops through an interruptible event
+- **Credential Isolation**: Resolves SDK credential values only from named environment variables
+
 ### Virtual Agent Router (`virtual_agent_router.py`)
 
 The router is responsible for:
@@ -62,11 +72,12 @@ python -m grpc_tools.protoc -Iproto --python_out=src/core --grpc_python_out=src/
 
 ### Request Flow
 
-1. **WxCC Request**: WxCC sends gRPC request to gateway
-2. **Router Lookup**: Gateway finds appropriate connector for agent
-3. **Connector Processing**: Connector processes request in vendor format
-4. **Response Conversion**: Response converted back to WxCC format
-5. **Stream Response**: Response streamed back to WxCC
+1. **Datasource Readiness**: When enabled, startup reconciles the BYODS registration and schedules renewal
+2. **WxCC Request**: WxCC sends gRPC request to gateway
+3. **Router Lookup**: Gateway finds appropriate connector for agent
+4. **Connector Processing**: Connector processes request in vendor format
+5. **Response Conversion**: Response converted back to WxCC format
+6. **Stream Response**: Response streamed back to WxCC
 
 ### Conversation Management
 
@@ -182,4 +193,4 @@ logging:
 
 ## License
 
-This code is licensed under the [Cisco Sample Code License v1.1](../LICENSE). See the main project README for details. 
+This code is licensed under the [Cisco Sample Code License v1.1](../LICENSE). See the main project README for details.

--- a/src/core/datasource_lifecycle.py
+++ b/src/core/datasource_lifecycle.py
@@ -1,0 +1,460 @@
+"""BYODS data source registration and token-renewal lifecycle."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from webex_byods import (
+    AccessTokenProvider,
+    OAuthRefreshTokenProvider,
+    ServiceAppCredentials,
+    StaticAccessTokenProvider,
+    WebexDataSourceClient,
+    WebexServiceAppTokenProvider,
+    decode_jwt_token,
+)
+
+DEFAULT_BYOVA_SCHEMA_ID = "5397013b-7920-4ffc-807c-e8a3e0a18f43"
+
+
+class DataSourceLifecycleError(RuntimeError):
+    """Raised when the gateway cannot establish its BYODS data source."""
+
+
+def _required_environment_value(config: dict[str, Any], key: str) -> str:
+    env_name = str(config.get(key, "")).strip()
+    if not env_name:
+        raise ValueError(f"data_source.auth.{key} must name an environment variable")
+
+    value = os.environ.get(env_name, "")
+    if not value:
+        raise ValueError(
+            f"Required BYODS credential environment variable is not set: {env_name}"
+        )
+    return value
+
+
+def create_token_provider(auth_config: dict[str, Any]) -> AccessTokenProvider:
+    """Create an SDK token provider from environment-backed configuration."""
+    auth_type = str(auth_config.get("type", "oauth_refresh")).strip().lower()
+
+    if auth_type == "static":
+        return StaticAccessTokenProvider(
+            _required_environment_value(auth_config, "access_token_env")
+        )
+
+    if auth_type == "oauth_refresh":
+        return OAuthRefreshTokenProvider(
+            client_id=_required_environment_value(auth_config, "client_id_env"),
+            client_secret=_required_environment_value(auth_config, "client_secret_env"),
+            refresh_token=_required_environment_value(auth_config, "refresh_token_env"),
+        )
+
+    if auth_type == "service_app":
+        personal_auth = auth_config.get("personal_auth")
+        if not isinstance(personal_auth, dict):
+            raise ValueError(
+                "data_source.auth.personal_auth must configure the token provider "
+                "used to obtain a service-app token"
+            )
+
+        credentials = ServiceAppCredentials(
+            app_id=_required_environment_value(auth_config, "app_id_env"),
+            client_id=_required_environment_value(auth_config, "client_id_env"),
+            client_secret=_required_environment_value(auth_config, "client_secret_env"),
+            target_org_id=_required_environment_value(auth_config, "target_org_id_env"),
+        )
+        return WebexServiceAppTokenProvider(
+            credentials=credentials,
+            personal_token_provider=create_token_provider(personal_auth),
+        )
+
+    raise ValueError(
+        "data_source.auth.type must be one of: oauth_refresh, service_app, static"
+    )
+
+
+def create_data_source_lifecycle(
+    config: dict[str, Any],
+    logger: logging.Logger | None = None,
+) -> DataSourceLifecycle | None:
+    """Build the configured lifecycle, or return ``None`` when it is disabled."""
+    lifecycle_config = config.get("data_source", {})
+    if not lifecycle_config.get("enabled", False):
+        return None
+
+    lifecycle_config = dict(lifecycle_config)
+    jwt_config = config.get("jwt_validation", {})
+
+    configured_url = str(lifecycle_config.get("url", "")).strip()
+    jwt_url = str(jwt_config.get("datasource_url", "")).strip()
+    data_source_url = configured_url or jwt_url
+    if not data_source_url:
+        raise ValueError(
+            "data_source requires a URL. Configure data_source.url or "
+            "jwt_validation.datasource_url."
+        )
+    if jwt_url and configured_url and jwt_url != configured_url:
+        raise ValueError(
+            "data_source.url must exactly match jwt_validation.datasource_url"
+        )
+
+    configured_schema = str(lifecycle_config.get("schema_id", "")).strip()
+    jwt_schema = str(jwt_config.get("datasource_schema_uuid", "")).strip()
+    schema_id = configured_schema or jwt_schema or DEFAULT_BYOVA_SCHEMA_ID
+    if jwt_schema and configured_schema and jwt_schema != configured_schema:
+        raise ValueError(
+            "data_source.schema_id must match jwt_validation.datasource_schema_uuid"
+        )
+
+    auth_config = lifecycle_config.get("auth")
+    if not isinstance(auth_config, dict):
+        raise ValueError("data_source.auth must be configured when enabled")
+
+    data_source_id = str(lifecycle_config.get("id", "")).strip()
+    data_source_id_env = str(lifecycle_config.get("id_env", "")).strip()
+    if not data_source_id and data_source_id_env:
+        data_source_id = os.environ.get(data_source_id_env, "").strip()
+
+    lifecycle_config.update(
+        {
+            "url": data_source_url,
+            "schema_id": schema_id,
+            "id": data_source_id,
+        }
+    )
+    client = WebexDataSourceClient(token_provider=create_token_provider(auth_config))
+    return DataSourceLifecycle(client, lifecycle_config, logger=logger)
+
+
+class DataSourceLifecycle:
+    """Ensure a BYODS data source exists and renew its JWS before expiry."""
+
+    def __init__(
+        self,
+        client: WebexDataSourceClient,
+        config: dict[str, Any],
+        *,
+        logger: logging.Logger | None = None,
+        now: Callable[[], datetime] | None = None,
+        stop_event: threading.Event | None = None,
+    ) -> None:
+        self.client = client
+        self.logger = logger or logging.getLogger(__name__)
+        self.url = str(config.get("url", "")).strip()
+        self.schema_id = str(config.get("schema_id", "")).strip()
+        self.audience = str(config.get("audience", "BYOVAGateway")).strip()
+        self.subject = str(config.get("subject", "callAudioData")).strip()
+        self.data_source_id = str(config.get("id", "")).strip() or None
+        self.token_lifetime_minutes = int(config.get("token_lifetime_minutes", 1440))
+        self.renewal_lead_time_minutes = int(
+            config.get("renewal_lead_time_minutes", 60)
+        )
+        self.retry_interval_seconds = int(config.get("retry_interval_seconds", 60))
+
+        self._now = now or (lambda: datetime.now(timezone.utc))
+        self._stop_event = stop_event or threading.Event()
+        self._renewal_thread: threading.Thread | None = None
+        self._current_data_source: dict[str, Any] | None = None
+
+        self._validate_config()
+
+    @property
+    def current_data_source(self) -> dict[str, Any] | None:
+        """Return the latest datasource representation received from Webex."""
+        return self._current_data_source
+
+    def _validate_config(self) -> None:
+        missing = [
+            name
+            for name, value in (
+                ("url", self.url),
+                ("schema_id", self.schema_id),
+                ("audience", self.audience),
+                ("subject", self.subject),
+            )
+            if not value
+        ]
+        if missing:
+            raise ValueError(
+                f"Missing required data_source configuration: {', '.join(missing)}"
+            )
+        if not 1 <= self.token_lifetime_minutes <= 1440:
+            raise ValueError(
+                "data_source.token_lifetime_minutes must be between 1 and 1440"
+            )
+        if not 0 < self.renewal_lead_time_minutes < self.token_lifetime_minutes:
+            raise ValueError(
+                "data_source.renewal_lead_time_minutes must be greater than zero "
+                "and less than token_lifetime_minutes"
+            )
+        if self.retry_interval_seconds <= 0:
+            raise ValueError(
+                "data_source.retry_interval_seconds must be greater than zero"
+            )
+
+    def start(self) -> dict[str, Any]:
+        """Register or reconcile the data source and start token renewal."""
+        if self._renewal_thread and self._renewal_thread.is_alive():
+            raise RuntimeError("BYODS data source lifecycle is already running")
+
+        self._stop_event.clear()
+        data_source = self._ensure_data_source()
+        expires_at = self._token_expiry(data_source)
+        delay = (
+            self._seconds_until_renewal(data_source) if expires_at is not None else 0.0
+        )
+
+        if delay <= 0:
+            if expires_at is None:
+                self.logger.warning(
+                    "BYODS response did not include a parseable token expiry; "
+                    "renewing immediately to establish a fresh token"
+                )
+            data_source = self._renew_token()
+            delay = self._seconds_until_renewal(data_source)
+
+        self._renewal_thread = threading.Thread(
+            target=self._renewal_loop,
+            args=(delay,),
+            name="byods-token-renewal",
+            daemon=True,
+        )
+        self._renewal_thread.start()
+        return data_source
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Stop the renewal worker without waiting for its scheduled deadline."""
+        self._stop_event.set()
+        thread = self._renewal_thread
+        if thread and thread.is_alive() and thread is not threading.current_thread():
+            thread.join(timeout=timeout)
+        self._renewal_thread = None
+
+    def _ensure_data_source(self) -> dict[str, Any]:
+        if self.data_source_id:
+            details = self._require_success(
+                self.client.get_data_source_details(self.data_source_id),
+                f"retrieve configured data source {self.data_source_id}",
+            )
+        else:
+            details = self._discover_data_source()
+
+        if details is None:
+            details = self._register_data_source()
+        elif self._requires_update(details):
+            details = self._update_data_source(details)
+
+        self.data_source_id = str(details.get("id", "")).strip() or None
+        if not self.data_source_id:
+            raise DataSourceLifecycleError(
+                "Webex BYODS response did not include a data source ID"
+            )
+
+        self._current_data_source = details
+        self.logger.info(
+            "BYODS data source ready: id=%s url=%s",
+            self.data_source_id,
+            self.url,
+        )
+        return details
+
+    def _discover_data_source(self) -> dict[str, Any] | None:
+        result = self._require_success(
+            self.client.list_all_data_sources(), "list data sources"
+        )
+        items = result.get("items", [])
+        if not isinstance(items, list):
+            raise DataSourceLifecycleError(
+                "Webex BYODS list response did not contain an items list"
+            )
+
+        exact_matches = [
+            item for item in items if self._matches_expected_configuration(item)
+        ]
+        if len(exact_matches) == 1:
+            return self._get_details_for_item(exact_matches[0])
+        if len(exact_matches) > 1:
+            raise DataSourceLifecycleError(
+                "Multiple BYODS data sources match this gateway. Configure "
+                "data_source.id (or id_env) to select one."
+            )
+
+        endpoint_matches = [
+            item for item in items if self._matches_endpoint_and_schema(item)
+        ]
+        if len(endpoint_matches) == 1:
+            return self._get_details_for_item(endpoint_matches[0])
+        if len(endpoint_matches) > 1:
+            raise DataSourceLifecycleError(
+                "Multiple BYODS data sources use this gateway URL and schema. "
+                "Configure data_source.id (or id_env) to select one."
+            )
+        return None
+
+    def _get_details_for_item(self, item: dict[str, Any]) -> dict[str, Any]:
+        item_id = str(item.get("id", "")).strip()
+        if not item_id:
+            raise DataSourceLifecycleError(
+                "Discovered BYODS data source did not include an ID"
+            )
+        return self._require_success(
+            self.client.get_data_source_details(item_id),
+            f"retrieve discovered data source {item_id}",
+        )
+
+    def _register_data_source(self) -> dict[str, Any]:
+        payload = self._desired_payload()
+        self.logger.info("Registering BYODS data source for %s", self.url)
+        return self._require_success(
+            self.client.register_data_source(payload), "register data source"
+        )
+
+    def _update_data_source(self, current: dict[str, Any]) -> dict[str, Any]:
+        data_source_id = str(current.get("id", "")).strip()
+        if not data_source_id:
+            raise DataSourceLifecycleError(
+                "Cannot update BYODS data source without an ID"
+            )
+
+        self.logger.info(
+            "Reconciling BYODS data source configuration: id=%s", data_source_id
+        )
+        payload = self._desired_payload(status="active")
+        return self._require_success(
+            self.client.update_data_source(data_source_id, payload),
+            f"update data source {data_source_id}",
+        )
+
+    def _renew_token(self) -> dict[str, Any]:
+        if not self.data_source_id:
+            raise DataSourceLifecycleError(
+                "Cannot renew BYODS token before a data source is established"
+            )
+
+        self.logger.info("Renewing BYODS data source token: id=%s", self.data_source_id)
+        result = self._require_success(
+            self.client.extend_data_source_token(
+                self.data_source_id,
+                token_lifetime_minutes=self.token_lifetime_minutes,
+            ),
+            f"renew data source token {self.data_source_id}",
+        )
+        self._current_data_source = result
+        self.logger.info(
+            "BYODS data source token renewed: id=%s expires=%s",
+            self.data_source_id,
+            result.get("tokenExpiryTime", "unknown"),
+        )
+        return result
+
+    def _renewal_loop(self, delay: float) -> None:
+        next_delay = delay
+        while not self._stop_event.wait(max(0.0, next_delay)):
+            try:
+                data_source = self._renew_token()
+                next_delay = self._seconds_until_renewal(data_source)
+            except Exception:
+                self.logger.exception(
+                    "BYODS token renewal failed; retrying in %s seconds",
+                    self.retry_interval_seconds,
+                )
+                next_delay = float(self.retry_interval_seconds)
+
+    def _seconds_until_renewal(self, data_source: dict[str, Any]) -> float:
+        expires_at = self._token_expiry(data_source)
+        if expires_at is None:
+            fallback = (
+                self.token_lifetime_minutes - self.renewal_lead_time_minutes
+            ) * 60
+            self.logger.warning(
+                "BYODS response did not include a parseable token expiry; "
+                "using a %s-second renewal interval",
+                fallback,
+            )
+            return float(fallback)
+
+        renew_at = expires_at - timedelta(minutes=self.renewal_lead_time_minutes)
+        return max(0.0, (renew_at - self._now()).total_seconds())
+
+    @staticmethod
+    def _token_expiry(data_source: dict[str, Any]) -> datetime | None:
+        expiry_value = data_source.get("tokenExpiryTime")
+        if isinstance(expiry_value, str) and expiry_value:
+            try:
+                parsed = datetime.fromisoformat(expiry_value.replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                return parsed.astimezone(timezone.utc)
+            except ValueError:
+                pass
+
+        token = data_source.get("jwsToken") or data_source.get("jwtToken")
+        if not token:
+            return None
+        claims = decode_jwt_token(token)
+        expires_at = claims.get("exp")
+        if isinstance(expires_at, (int, float)):
+            return datetime.fromtimestamp(expires_at, tz=timezone.utc)
+        return None
+
+    def _desired_payload(self, *, status: str | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schemaId": self.schema_id,
+            "url": self.url,
+            "audience": self.audience,
+            "subject": self.subject,
+            "nonce": str(uuid.uuid4()),
+            "tokenLifetimeMinutes": self.token_lifetime_minutes,
+        }
+        if status:
+            payload["status"] = status
+        return payload
+
+    def _matches_endpoint_and_schema(self, data_source: dict[str, Any]) -> bool:
+        claims = self._claims(data_source)
+        schema_id = data_source.get("schemaId") or claims.get(
+            "com.cisco.datasource.schema.uuid"
+        )
+        return data_source.get("url") == self.url and schema_id == self.schema_id
+
+    def _matches_expected_configuration(self, data_source: dict[str, Any]) -> bool:
+        claims = self._claims(data_source)
+        return (
+            self._matches_endpoint_and_schema(data_source)
+            and (data_source.get("audience") or claims.get("aud")) == self.audience
+            and (data_source.get("subject") or claims.get("sub")) == self.subject
+        )
+
+    def _requires_update(self, data_source: dict[str, Any]) -> bool:
+        return (
+            not self._matches_expected_configuration(data_source)
+            or data_source.get("status", "active") != "active"
+        )
+
+    @staticmethod
+    def _claims(data_source: dict[str, Any]) -> dict[str, Any]:
+        token = data_source.get("jwsToken") or data_source.get("jwtToken")
+        return decode_jwt_token(token) if token else {}
+
+    @staticmethod
+    def _require_success(result: dict[str, Any], operation: str) -> dict[str, Any]:
+        if not result.get("success"):
+            status_code = result.get("status_code")
+            status_suffix = f" (HTTP {status_code})" if status_code else ""
+            raise DataSourceLifecycleError(
+                f"Failed to {operation}{status_suffix}: "
+                f"{result.get('error', 'unknown error')}"
+            )
+
+        data = result.get("data")
+        if not isinstance(data, dict):
+            raise DataSourceLifecycleError(
+                f"Failed to {operation}: response data was not an object"
+            )
+        return data

--- a/tests/test_datasource_lifecycle.py
+++ b/tests/test_datasource_lifecycle.py
@@ -1,0 +1,278 @@
+"""Tests for BYODS datasource startup registration and token renewal."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, call
+
+import pytest
+
+from src.core.datasource_lifecycle import (
+    DataSourceLifecycle,
+    DataSourceLifecycleError,
+    create_data_source_lifecycle,
+)
+
+NOW = datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc)
+SCHEMA_ID = "5397013b-7920-4ffc-807c-e8a3e0a18f43"
+URL = "https://gateway.example.com"
+
+
+def lifecycle_config(**overrides):
+    config = {
+        "url": URL,
+        "schema_id": SCHEMA_ID,
+        "audience": "BYOVAGateway",
+        "subject": "callAudioData",
+        "token_lifetime_minutes": 1440,
+        "renewal_lead_time_minutes": 60,
+        "retry_interval_seconds": 10,
+    }
+    config.update(overrides)
+    return config
+
+
+def data_source(
+    *,
+    data_source_id="source-1",
+    expires_at=None,
+    audience="BYOVAGateway",
+    subject="callAudioData",
+    status="active",
+):
+    return {
+        "id": data_source_id,
+        "url": URL,
+        "schemaId": SCHEMA_ID,
+        "audience": audience,
+        "subject": subject,
+        "status": status,
+        "tokenExpiryTime": (expires_at or NOW + timedelta(hours=24))
+        .isoformat()
+        .replace("+00:00", "Z"),
+    }
+
+
+def success(data):
+    return {"success": True, "data": data, "status_code": 200}
+
+
+def test_factory_returns_none_when_management_is_disabled():
+    assert create_data_source_lifecycle({"data_source": {"enabled": False}}) is None
+
+
+def test_factory_reuses_jwt_url_and_schema(monkeypatch):
+    monkeypatch.setenv("BYODS_TOKEN", "secret-token")
+    config = {
+        "jwt_validation": {
+            "datasource_url": URL,
+            "datasource_schema_uuid": SCHEMA_ID,
+        },
+        "data_source": {
+            "enabled": True,
+            "auth": {
+                "type": "static",
+                "access_token_env": "BYODS_TOKEN",
+            },
+        },
+    }
+
+    lifecycle = create_data_source_lifecycle(config)
+
+    assert lifecycle is not None
+    assert lifecycle.url == URL
+    assert lifecycle.schema_id == SCHEMA_ID
+
+
+def test_factory_rejects_url_that_differs_from_jwt_validation(monkeypatch):
+    monkeypatch.setenv("BYODS_TOKEN", "secret-token")
+    config = {
+        "jwt_validation": {"datasource_url": URL},
+        "data_source": {
+            "enabled": True,
+            "url": "https://other.example.com",
+            "auth": {
+                "type": "static",
+                "access_token_env": "BYODS_TOKEN",
+            },
+        },
+    }
+
+    with pytest.raises(ValueError, match="must exactly match"):
+        create_data_source_lifecycle(config)
+
+
+def test_start_registers_when_no_matching_data_source_exists():
+    client = Mock()
+    registered = data_source()
+    client.list_all_data_sources.return_value = success({"items": []})
+    client.register_data_source.return_value = {
+        "success": True,
+        "data": registered,
+        "status_code": 201,
+    }
+    lifecycle = DataSourceLifecycle(client, lifecycle_config(), now=lambda: NOW)
+
+    result = lifecycle.start()
+    lifecycle.stop()
+
+    assert result == registered
+    payload = client.register_data_source.call_args.args[0]
+    assert payload["schemaId"] == SCHEMA_ID
+    assert payload["url"] == URL
+    assert payload["audience"] == "BYOVAGateway"
+    assert payload["subject"] == "callAudioData"
+    assert payload["tokenLifetimeMinutes"] == 1440
+    assert payload["nonce"]
+    client.update_data_source.assert_not_called()
+    client.extend_data_source_token.assert_not_called()
+
+
+def test_start_discovers_existing_data_source_without_creating_duplicate():
+    client = Mock()
+    existing = data_source()
+    client.list_all_data_sources.return_value = success({"items": [existing]})
+    client.get_data_source_details.return_value = success(existing)
+    lifecycle = DataSourceLifecycle(client, lifecycle_config(), now=lambda: NOW)
+
+    lifecycle.start()
+    lifecycle.stop()
+
+    client.get_data_source_details.assert_called_once_with("source-1")
+    client.register_data_source.assert_not_called()
+    client.update_data_source.assert_not_called()
+
+
+def test_start_reconciles_configuration_drift():
+    client = Mock()
+    drifted = data_source(audience="old-audience", status="disabled")
+    updated = data_source()
+    client.list_all_data_sources.return_value = success({"items": [drifted]})
+    client.get_data_source_details.return_value = success(drifted)
+    client.update_data_source.return_value = success(updated)
+    lifecycle = DataSourceLifecycle(client, lifecycle_config(), now=lambda: NOW)
+
+    lifecycle.start()
+    lifecycle.stop()
+
+    update_id, payload = client.update_data_source.call_args.args
+    assert update_id == "source-1"
+    assert payload["audience"] == "BYOVAGateway"
+    assert payload["status"] == "active"
+    assert payload["nonce"]
+    client.register_data_source.assert_not_called()
+
+
+def test_start_renews_immediately_when_token_is_inside_lead_time():
+    client = Mock()
+    expiring = data_source(expires_at=NOW + timedelta(minutes=30))
+    renewed = data_source(expires_at=NOW + timedelta(hours=24))
+    client.get_data_source_details.return_value = success(expiring)
+    client.extend_data_source_token.return_value = success(renewed)
+    lifecycle = DataSourceLifecycle(
+        client,
+        lifecycle_config(id="source-1"),
+        now=lambda: NOW,
+    )
+
+    result = lifecycle.start()
+    lifecycle.stop()
+
+    assert result == renewed
+    client.extend_data_source_token.assert_called_once_with(
+        "source-1", token_lifetime_minutes=1440
+    )
+
+
+def test_start_renews_immediately_when_expiry_is_missing():
+    client = Mock()
+    current = data_source()
+    current.pop("tokenExpiryTime")
+    renewed = data_source(expires_at=NOW + timedelta(hours=24))
+    client.get_data_source_details.return_value = success(current)
+    client.extend_data_source_token.return_value = success(renewed)
+    lifecycle = DataSourceLifecycle(
+        client,
+        lifecycle_config(id="source-1"),
+        now=lambda: NOW,
+    )
+
+    lifecycle.start()
+    lifecycle.stop()
+
+    client.extend_data_source_token.assert_called_once_with(
+        "source-1", token_lifetime_minutes=1440
+    )
+
+
+def test_start_fails_when_configured_data_source_cannot_be_retrieved():
+    client = Mock()
+    client.get_data_source_details.return_value = {
+        "success": False,
+        "error": "not found",
+        "status_code": 404,
+    }
+    lifecycle = DataSourceLifecycle(
+        client, lifecycle_config(id="missing"), now=lambda: NOW
+    )
+
+    with pytest.raises(
+        DataSourceLifecycleError, match="retrieve configured data source"
+    ):
+        lifecycle.start()
+
+
+def test_renewal_loop_waits_until_deadline_then_renews():
+    client = Mock()
+    renewed = data_source(expires_at=NOW + timedelta(hours=24))
+    client.extend_data_source_token.return_value = success(renewed)
+    stop_event = Mock()
+    stop_event.wait.side_effect = [False, True]
+    lifecycle = DataSourceLifecycle(
+        client,
+        lifecycle_config(id="source-1"),
+        now=lambda: NOW,
+        stop_event=stop_event,
+    )
+
+    lifecycle._renewal_loop(300)
+
+    client.extend_data_source_token.assert_called_once_with(
+        "source-1", token_lifetime_minutes=1440
+    )
+    assert stop_event.wait.call_args_list == [call(300), call(23 * 60 * 60)]
+
+
+def test_renewal_loop_retries_after_sdk_failure():
+    client = Mock()
+    client.extend_data_source_token.return_value = {
+        "success": False,
+        "error": "temporary failure",
+        "status_code": 503,
+    }
+    stop_event = Mock()
+    stop_event.wait.side_effect = [False, True]
+    lifecycle = DataSourceLifecycle(
+        client,
+        lifecycle_config(id="source-1", retry_interval_seconds=10),
+        now=lambda: NOW,
+        stop_event=stop_event,
+        logger=Mock(),
+    )
+
+    lifecycle._renewal_loop(300)
+
+    assert stop_event.wait.call_args_list == [call(300), call(10.0)]
+
+
+@pytest.mark.parametrize(
+    ("token_lifetime", "lead_time"),
+    [(0, 1), (1441, 1), (60, 0), (60, 60), (60, 61)],
+)
+def test_invalid_renewal_configuration_is_rejected(token_lifetime, lead_time):
+    with pytest.raises(ValueError):
+        DataSourceLifecycle(
+            Mock(),
+            lifecycle_config(
+                token_lifetime_minutes=token_lifetime,
+                renewal_lead_time_minutes=lead_time,
+            ),
+        )

--- a/tests/test_main_datasource_lifecycle.py
+++ b/tests/test_main_datasource_lifecycle.py
@@ -1,0 +1,51 @@
+"""Integration tests for the BYODS lifecycle in gateway startup."""
+
+from contextlib import ExitStack
+from unittest.mock import Mock, patch
+
+import main
+
+
+def test_datasource_is_ready_before_grpc_starts_and_stops_on_shutdown():
+    events = []
+    config = {
+        "connectors": {},
+        "gateway": {"host": "127.0.0.1", "port": 50051},
+        "monitoring": {"enabled": False},
+        "jwt_validation": {"enabled": False},
+        "data_source": {"enabled": True},
+    }
+
+    router = Mock()
+    router.get_connector_info.return_value = {"loaded_connectors": []}
+    router.get_all_available_agents.return_value = []
+
+    gateway_server = Mock()
+    grpc_server = Mock()
+    grpc_server.start.side_effect = lambda: events.append("grpc")
+    lifecycle = Mock()
+    lifecycle.start.side_effect = lambda: events.append("datasource")
+    lifecycle.data_source_id = "source-1"
+    lifecycle.current_data_source = {"tokenExpiryTime": "2026-07-30T12:00:00Z"}
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("main.load_config", return_value=config))
+        stack.enter_context(patch("main.setup_logging"))
+        stack.enter_context(patch("main.VirtualAgentRouter", return_value=router))
+        stack.enter_context(
+            patch("main.WxCCGatewayServer", return_value=gateway_server)
+        )
+        stack.enter_context(patch("main.HealthCheckService"))
+        stack.enter_context(patch("main.create_jwt_interceptor", return_value=None))
+        stack.enter_context(
+            patch("main.create_data_source_lifecycle", return_value=lifecycle)
+        )
+        stack.enter_context(patch("main.grpc.server", return_value=grpc_server))
+        stack.enter_context(patch("main.add_VoiceVirtualAgentServicer_to_server"))
+        stack.enter_context(patch("main.health_pb2_grpc.add_HealthServicer_to_server"))
+        main.main()
+
+    assert events == ["datasource", "grpc"]
+    lifecycle.stop.assert_called_once_with()
+    gateway_server.shutdown.assert_called_once_with()
+    grpc_server.stop.assert_called_once_with(grace=5)


### PR DESCRIPTION
## Summary

- use `webex-byods-sdk==0.2.0` to discover or register the gateway datasource before gRPC starts accepting traffic
- reconcile URL, schema, audience, subject, and active status on startup
- renew the datasource JWS before expiry, retry transient renewal failures, and stop the worker during graceful shutdown
- support environment-backed OAuth refresh, service-app, and static token providers without storing credentials in YAML
- add unit and startup-order coverage
- update the local audio, local development, JWT, customer evaluation, and production-readiness guides with the automatic registration workflow

## Why

BYOVA deployments currently require operators to register and periodically renew the BYODS datasource outside the gateway. Owning that lifecycle at startup prevents expired datasource tokens from interrupting WxCC connectivity and keeps registration settings aligned with JWT validation.

The guide updates make the required order explicit: establish the public endpoint, configure the Service App credentials and lifecycle, start the gateway, then use the printed datasource ID in the Contact Center virtual-agent feature.

## Validation

- `venv/bin/python -m pytest -q` — 377 passed
- `venv/bin/ruff check src/core/datasource_lifecycle.py main.py tests/test_datasource_lifecycle.py tests/test_main_datasource_lifecycle.py`
- `venv/bin/python -m pip check`
- `git diff --check`

No live Webex datasource was modified during local validation; SDK interactions are covered with mocked responses.
