### PR TITLE
fix: exclude development tools from runtime releases

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -391,6 +391,20 @@ See [README.md](README.md) for complete JWT authentication documentation and tro
 
 ## Working with the Codebase
 
+### Runtime Release Artifacts
+
+All EC2, VM, container-context, and server release bundles must be built with the runtime
+allowlist:
+
+```bash
+scripts/build-runtime-release.sh --ref HEAD --output /tmp/byova-gateway-runtime.tar.gz
+```
+
+Do not deploy or archive the repository root. In particular, `tools/byova_e2e/`, `tests/`,
+`docs/`, npm manifests and lockfiles, and AppleDouble files are development-only and must not
+be present on gateway hosts. Verify the generated archive and scan the installed runtime
+filesystem, not the source checkout, before closing dependency incidents.
+
 To begin development (for learning or building upon this example):
    
    Always use a virtual environment to keep dependencies isolated:

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ webex-byova-gateway-python/
 ├── config/             # Gateway and connector configuration
 ├── docs/               # Evaluation, security, testing, and operations guides
 ├── proto/              # BYOVA and health protocol definitions
+├── scripts/            # Runtime release tooling
 ├── src/
 │   ├── auth/           # gRPC JWT validation
 │   ├── connectors/     # Virtual-agent connectors
@@ -217,9 +218,33 @@ webex-byova-gateway-python/
 │   ├── monitoring/     # Development monitoring interface
 │   └── utils/          # Audio utilities
 ├── tests/              # Automated test suite
+├── tools/              # Local development and end-to-end test tools
 ├── main.py             # Application entry point
 └── requirements.txt    # Python dependencies
 ```
+
+## Build a Runtime Release Artifact
+
+Build EC2 and server releases with the allowlisted runtime artifact builder:
+
+```bash
+scripts/build-runtime-release.sh \
+  --ref HEAD \
+  --output /tmp/byova-gateway-runtime.tar.gz
+```
+
+The archive contains only the Python gateway runtime: `main.py`, Python dependency
+metadata, `audio/`, `config/`, `proto/`, and `src/`. It deliberately excludes `tools/`,
+`tests/`, `docs/`, JavaScript package manifests and lockfiles, and macOS AppleDouble files.
+
+`tools/byova_e2e/` is a local validation utility. Its browser dependencies must not be copied
+to an EC2 gateway or included in an image or release archive. Deploying the whole repository
+can cause host scanners to report development-only dependencies as if the gateway loaded
+them at runtime.
+
+Before deployment, scan the generated archive and verify its checksum. Keep environment
+configuration and secrets outside the artifact and inject them through the deployment
+system.
 
 ## Development
 

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -422,6 +422,9 @@ other obligations that apply to the contact center.
 ## 10. Establish a production delivery process
 
 - Build immutable, versioned artifacts in CI from reviewed source.
+- Build gateway runtime archives with `scripts/build-runtime-release.sh`. Do not deploy the
+  repository root: local tools, tests, documentation, JavaScript manifests and lockfiles,
+  and workstation metadata are not runtime components and must not reach gateway hosts.
 - Run formatting, linting, type checks, unit tests, integration tests, dependency scans,
   secret scans, and artifact/image scans on every change.
 - Generate gRPC code deterministically and detect incompatible protocol changes.
@@ -548,6 +551,8 @@ answer **yes** to every applicable item:
 - [ ] Secrets use managed storage and short-lived/workload credentials where possible.
 - [ ] Debug/test endpoints and production audio logging are disabled or separately approved.
 - [ ] Privacy, security, compliance, retention, and data-residency reviews are complete.
+- [ ] The deployed filesystem contains only the allowlisted gateway runtime and has no local
+  test tools or JavaScript package manifests and lockfiles.
 - [ ] CI/CD produces immutable scanned artifacts with canary and rollback support.
 - [ ] Vendor quotas, throttling behavior, outage handling, and support escalation are documented.
 - [ ] Disaster recovery meets approved recovery objectives and has been exercised.

--- a/scripts/build-runtime-release.sh
+++ b/scripts/build-runtime-release.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Build an EC2 runtime release archive from an allowlist of tracked files.
+
+Usage:
+  scripts/build-runtime-release.sh --output <archive.tar.gz> [--ref <git-ref>]
+
+Options:
+  --output  Destination .tar.gz path (required)
+  --ref     Git commit, tag, or branch to archive (default: HEAD)
+  --help    Show this help
+EOF
+}
+
+output=""
+ref="HEAD"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      [[ $# -ge 2 ]] || { echo "error: --output requires a value" >&2; exit 2; }
+      output="$2"
+      shift 2
+      ;;
+    --ref)
+      [[ $# -ge 2 ]] || { echo "error: --ref requires a value" >&2; exit 2; }
+      ref="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n "$output" ]] || { echo "error: --output is required" >&2; usage >&2; exit 2; }
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+resolved_ref="$(git rev-parse --verify "${ref}^{commit}")"
+
+required_paths=(
+  main.py
+  requirements.txt
+  config
+  proto
+  src
+)
+
+runtime_paths=(
+  LICENSE
+  main.py
+  pyproject.toml
+  requirements.txt
+  audio
+  config
+  proto
+  src
+)
+
+for path in "${required_paths[@]}"; do
+  if ! git cat-file -e "${resolved_ref}:${path}" 2>/dev/null; then
+    echo "error: required runtime path is missing at ${ref}: ${path}" >&2
+    exit 1
+  fi
+done
+
+archive_paths=()
+for path in "${runtime_paths[@]}"; do
+  if git cat-file -e "${resolved_ref}:${path}" 2>/dev/null; then
+    archive_paths+=("$path")
+  fi
+done
+
+mkdir -p "$(dirname "$output")"
+output_dir="$(cd "$(dirname "$output")" && pwd -P)"
+output_path="${output_dir}/$(basename "$output")"
+temporary_archive="$(mktemp "${TMPDIR:-/tmp}/byova-runtime-release.XXXXXX")"
+trap 'rm -f "$temporary_archive"' EXIT
+
+git archive --format=tar "$resolved_ref" -- "${archive_paths[@]}" \
+  | gzip -n > "$temporary_archive"
+
+archive_listing="$(tar -tzf "$temporary_archive")"
+for path in "${required_paths[@]}"; do
+  if ! grep -Eq "^${path}(/|$)" <<<"$archive_listing"; then
+    echo "error: runtime archive is missing required path: ${path}" >&2
+    exit 1
+  fi
+done
+
+forbidden_pattern='(^|/)(tools|tests|docs)(/|$)|(^|/)(package.json|package-lock.json|npm-shrinkwrap.json|yarn.lock|pnpm-lock.yaml)$|(^|/)\._'
+if grep -Eq "$forbidden_pattern" <<<"$archive_listing"; then
+  echo "error: runtime archive contains development-only or npm manifest files" >&2
+  grep -E "$forbidden_pattern" <<<"$archive_listing" >&2
+  exit 1
+fi
+
+mv "$temporary_archive" "$output_path"
+trap - EXIT
+
+if command -v sha256sum >/dev/null 2>&1; then
+  checksum="$(sha256sum "$output_path" | awk '{print $1}')"
+else
+  checksum="$(shasum -a 256 "$output_path" | awk '{print $1}')"
+fi
+
+echo "Runtime release: $output_path"
+echo "Git commit: $resolved_ref"
+echo "SHA-256: $checksum"

--- a/tests/test_runtime_release_artifact.py
+++ b/tests/test_runtime_release_artifact.py
@@ -1,0 +1,44 @@
+import subprocess
+import tarfile
+from pathlib import Path, PurePosixPath
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+BUILD_SCRIPT = REPOSITORY_ROOT / "scripts" / "build-runtime-release.sh"
+REQUIRED_MEMBERS = {
+    "main.py",
+    "requirements.txt",
+}
+FORBIDDEN_DIRECTORIES = {"docs", "tests", "tools"}
+FORBIDDEN_FILENAMES = {
+    "package.json",
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+}
+
+
+def test_runtime_release_contains_only_runtime_files(tmp_path: Path) -> None:
+    archive_path = tmp_path / "byova-gateway-runtime.tar.gz"
+
+    subprocess.run(
+        [str(BUILD_SCRIPT), "--ref", "HEAD", "--output", str(archive_path)],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with tarfile.open(archive_path, "r:gz") as archive:
+        members = {member.name for member in archive.getmembers()}
+
+    assert REQUIRED_MEMBERS <= members
+    assert any(name.startswith("config/") for name in members)
+    assert any(name.startswith("proto/") for name in members)
+    assert any(name.startswith("src/") for name in members)
+
+    for member in members:
+        path = PurePosixPath(member)
+        assert not (FORBIDDEN_DIRECTORIES & set(path.parts))
+        assert path.name not in FORBIDDEN_FILENAMES
+        assert not any(part.startswith("._") for part in path.parts)


### PR DESCRIPTION
## Summary

- add an allowlisted, reproducible runtime release builder for EC2 and server deployments
- fail release construction if development tools, tests, documentation, npm manifests or lockfiles, or AppleDouble metadata enter the archive
- add regression coverage and document the runtime/development artifact boundary

## Root cause

The local `tools/byova_e2e` browser utility has a transitive dependency on deprecated npm `request`. Whole-repository deployment archives copied that utility and its lockfile onto gateway hosts even though the Python gateway never installs or loads the package. Filesystem scanning therefore attributed a development-only dependency to the runtime instance.

## Impact

Gateway runtime artifacts now contain only the tracked Python application files required to run the service. This prevents development-only JavaScript dependencies from reaching deployed hosts without changing gateway behavior.

## Validation

- `ruff check tests/test_runtime_release_artifact.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_runtime_release_artifact.py`
- `bash -n scripts/build-runtime-release.sh`
- built the committed release twice and verified identical SHA-256 hashes
- verified the generated archive contains no `tools/`, `tests/`, `docs/`, npm manifests or lockfiles, or `._*` metadata
